### PR TITLE
Fixes issues with broken download links, licenses not showing on in-browser receipts

### DIFF
--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -1,5 +1,5 @@
 <?php
-/** 
+/**
  * EDD Archives Widget
  *
  * @package      EDD Widgets Pack
@@ -14,7 +14,7 @@
  * EDD Archives Widget Class
  *
  * EDD Downloads archive.
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
@@ -38,13 +38,9 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
             add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
             add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-            // enable date based archives for downloads
-            add_action( 'pre_get_posts', array( &$this, 'pre_get_posts_filter' ) );
-            
             // contruct widget
             parent::__construct( false, __( 'EDD Archives', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A monthly archive of your site\'s %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
         }
-
 
         /**
          * Widget
@@ -60,7 +56,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 
                 // get the title and apply filters
                 $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
-                
+
                 // get show count boolean
                 $show_count = isset( $instance['show_count'] ) && $instance['show_count'] === 1 ? 1 : 0;
 
@@ -77,12 +73,16 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 
                 // add download post type to archives
                 add_filter( 'getarchives_where' , array( &$this, 'getarchives_where_filter' ) , 10 , 2 );
-                
+
+                add_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
+
                 // output the archives
                 $out .= wp_get_archives( array( 'echo' => 0, 'show_post_count' => $show_count ) );
-                
+
                 // remove filter
                 remove_filter( 'getarchives_where' , array( &$this, 'getarchives_where_filter' ), 10, 2 );
+
+                remove_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
 
                 // finish the list
                 $out .= "</ul>\n";
@@ -91,7 +91,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
                 $cache = $args['before_widget'] . $out . $args['after_widget'];
 
                 // store the result on a temporal transient
-                set_transient( 'edd_widgets_archives', $cache );
+                set_transient( 'edd_widgets_archives', $cache, DAY_IN_SECONDS );
 
             }
 
@@ -106,10 +106,22 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
          * @return   string
          * @since    1.0
         */
-        
+
         function getarchives_where_filter( $where , $r )
         {
             return str_replace( "post_type = 'post'" , "post_type = 'download'" , $where );
+        }
+
+
+        /**
+         * Filters the month link so the links go to the
+         * date archives for the download post type.
+         *
+         * @since 1.3
+         * @return string
+         */
+        function month_link( $monthlink, $year, $month ) {
+            return $monthlink . '?post_type="download"';
         }
 
 
@@ -121,12 +133,12 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
         */
 
         function update( $new_instance, $old_instance )
-        {     
+        {
             $instance = $old_instance;
 
             // sanitize title
             $instance['title'] = strip_tags( $new_instance['title'] );
-            
+
             // sanitize show price
             $instance['show_count'] = strip_tags( $new_instance['show_count'] );
             $instance['show_count'] = $instance['show_count'] === '1' ? 1 : 0;
@@ -143,7 +155,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
          *
          * @return   void
          * @since    1.0
-        */    
+        */
 
         function delete_cache()
         {
@@ -169,42 +181,9 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
                 </p>
                 <p>
                     <input id="<?php echo $this->get_field_id( 'show_count' ); ?>" name="<?php echo $this->get_field_name( 'show_count' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_count' ); ?>"><?php printf( __('Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label> 
+                    <label for="<?php echo $this->get_field_id( 'show_count' ); ?>"><?php printf( __('Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
                 </p>
             <?php
-        }
-
-
-        /**
-         * Rewrite Rules Array
-         *
-         * @author   Copyright 2012 Jennifer M. Dodd <jmdodd@gmail.com>
-         * @license  Released under the GPLv2 ( or later ).
-         * @return   void
-         * @since    1.0
-        */
-
-        function pre_get_posts_filter( $query ) {
-
-            if ( ! is_active_widget( false, false, $this->id_base, true ) )
-            return;
-
-            if ( ! is_preview() && ! is_admin() && ! is_singular() && ! is_404() && ! is_home() ) {
-                if ( ! $query->is_feed ) {
-                    $my_post_type = get_query_var( 'post_type' );
-                    if ( empty( $my_post_type ) ) {
-                        $args = array( 
-                            'public' => true , 
-                            '_builtin' => false
-                         );
-                        $output = 'names';
-                        $operator = 'and';
-
-                        $post_types = array_merge( array( 'download' ), array( 'post' ) );
-                        $query->set( 'post_type', $post_types );
-                    }
-                }
-            } 
         }
 
     }
@@ -213,7 +192,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 
 /**
  * Register Archives Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
                 $cache = $args['before_widget'] . $out . $args['after_widget'];
 
                 // store the result on a temporal transient
-                set_transient( 'edd_widgets_archives', $cache, DAY_IN_SECONDS );
+                set_transient( 'edd_widgets_archives', $cache );
 
             }
 

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -1,5 +1,5 @@
 <?php
-/** 
+/**
  * EDD Downloads Calendar Widget
  *
  * @package      EDD Widgets Pack
@@ -14,7 +14,7 @@
  * EDD Downloads Calendar Widget Class
  *
  * A calendar of your site’s EDD downloads.
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
@@ -31,17 +31,14 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
         */
 
         function __construct()
-        {        
+        {
             // hook updates
             add_action( 'save_post', array( &$this, 'delete_cache' ) );
             add_action( 'delete_post', array( &$this, 'delete_cache' ) );
             add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
             add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-            // enable date based archives for downloads
-            add_action( 'pre_get_posts', array( &$this, 'pre_get_posts_filter' ) );
-
-            // contruct widget
+            // construct widget
             parent::__construct( false, sprintf( __( 'EDD %s Calendar', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A calendar of your site\'s EDD %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
         }
 
@@ -56,34 +53,27 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
         function widget( $args, $instance )
         {
 
-           if ( false == $cache = get_transient( 'edd_widgets_downloads_calendar' ) ) {
+            // get the title and apply filters
+            $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-                // get the title and apply filters
-                $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+            // set the limit
+            $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-                // set the limit 
-                $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4; 
+            // start collecting the output
+            $out = "";
 
-                // start collecting the output
-                $out = "";
+            // check if there is a title
+            if ( $title ) {
+                // add the title to the ouput
+                $out .= $args['before_title'] . $title . $args['after_title'];
+            }
 
-                // check if there is a title
-                if ( $title ) {
-                    // add the title to the ouput
-                    $out .= $args['before_title'] . $title . $args['after_title'];
-                }
+            $out .= $this->get_calendar();
 
-                $out .= $this->get_calendar();
+            // set the widget's containers
+            $out = $args['before_widget'] . $out . $args['after_widget'];
 
-                // set the widget's containers
-                $cache = $args['before_widget'] . $out . $args['after_widget'];
-
-                // store the result on a temporal transient
-                set_transient( 'edd_widgets_downloads_calendar', $cache );
-
-           }
-
-            echo $cache;
+            echo $out;
 
         }
 
@@ -96,7 +86,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
         */
 
         function update( $new_instance, $old_instance )
-        {     
+        {
             $instance = $old_instance;
 
             // sanitize title
@@ -114,14 +104,14 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
          *
          * @return   void
          * @since    1.0
-        */    
+        */
 
         function delete_cache()
         {
             // check if widget is active
             if ( ! is_active_widget( false, false, $this->id_base, true ) )
             return;
-                
+
             // delete this widget's transient
             delete_transient( 'edd_widgets_downloads_calendar' );
         }
@@ -238,7 +228,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
             <tr>';
 
             if ( $previous ) {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $previous->month ), date( 'Y', mktime( 0, 0 , 0, $previous->month, 1, $previous->year ) ), edd_get_label_plural( true ) ) ) . '">&laquo; ' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) . '</a></td>';
+                $calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $previous->month ), date( 'Y', mktime( 0, 0 , 0, $previous->month, 1, $previous->year ) ), edd_get_label_plural( true ) ) ) . '">&laquo; ' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) . '</a></td>';
             } else {
                 $calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
             }
@@ -246,7 +236,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
             $calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
 
             if ( $next ) {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $next->month ), date( 'Y', mktime( 0, 0 , 0, $next->month, 1, $next->year ) ), edd_get_label_plural( true ) ) ) . '">' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) . ' &raquo;</a></td>';
+                $calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $next->month ), date( 'Y', mktime( 0, 0 , 0, $next->month, 1, $next->year ) ), edd_get_label_plural( true ) ) ) . '">' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) . ' &raquo;</a></td>';
             } else {
                 $calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
             }
@@ -314,7 +304,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
                     $calendar_output .= '<td>';
 
                 if ( in_array( $day, $daywithpost ) ) // any posts today?
-                        $calendar_output .= '<a href="' . get_day_link( $thisyear, $thismonth, $day ) . '" title="' . esc_attr( $ak_titles_for_day[ $day ] ) . "\">$day</a>";
+                        $calendar_output .= '<a href="' . get_day_link( $thisyear, $thismonth, $day ) . '?post_type=download" title="' . esc_attr( $ak_titles_for_day[ $day ] ) . "\">$day</a>";
                 else
                     $calendar_output .= $day;
                 $calendar_output .= '</td>';
@@ -332,47 +322,14 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
             return apply_filters( 'edd_widgets_pack_get_downloads_calendar',  $calendar_output );
 
         }
-
-
-        /**
-         * Rewrite Rules Array
-         *
-         * @author   Copyright 2012 Jennifer M. Dodd <jmdodd@gmail.com>
-         * @license  Released under the GPLv2 ( or later ).
-         * @return   void
-         * @since    1.0
-        */
-
-        function pre_get_posts_filter( $query ) {
-            
-            if ( ! is_active_widget( false, false, $this->id_base, true ) )
-            return;
-            
-            if ( ! is_preview() && ! is_admin() && ! is_singular() && ! is_404() && ! is_home() ) {
-                if ( ! $query->is_feed ) {
-                    $my_post_type = get_query_var( 'post_type' );
-                    if ( empty( $my_post_type ) ) {
-                        $args = array( 
-                            'public' => true , 
-                            '_builtin' => false
-                         );
-                        $output = 'names';
-                        $operator = 'and';
-
-                        $post_types = array_merge( array( 'download' ), array( 'post' ) );
-                        $query->set( 'post_type', $post_types );
-                    }
-                }
-            } 
-        }
-        
     }
-} 
+
+}
 
 
 /**
  * Register Downloads Calendar Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
@@ -380,17 +337,17 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 if ( ! function_exists( 'edd_widgets_pack_register_downloads_calendar_widget' ) ) {
     function edd_widgets_pack_register_downloads_calendar_widget() {
-        
+
         // get the EDD archives constant
         $archives = true;
         if( defined( 'EDD_DISABLE_ARCHIVE' ) && EDD_DISABLE_ARCHIVE == true ) {
             $archives = false;
         }
-        
+
         // no archives? then nothing to do here
         if ( $archives === false )
         return;
-        
+
         register_widget( 'EDD_Downloads_Calendar' );
     }
 }


### PR DESCRIPTION
and possibly other queries. #7.

@pippinsplugins can you review this to make sure I'm not breaking anything?

##### Notes
- this fixes broken download links in emails and in-browser receipts (the primary purpose of this PR)
- also fixes broken pagination in the calendar widget (by removing the transient that was caching only 1 month's output)
- fixes license keys not showing on in-browser receipts
- removes all reliance on pre_get_posts (which was breaking various queries) by appending `?post_type=download` to calendar and archive links output by the widgets.

