### PR TITLE
# 16 PHP Notices and Formatting

### DIFF
--- a/edd-widgets-pack.php
+++ b/edd-widgets-pack.php
@@ -19,31 +19,31 @@ Text Domain: edd-widgets-pack
  * @return   void
  * @access   private
  * @since    1.0
-*/
-
+ */
 if ( ! function_exists( 'edd_widgets_pack_init' ) ) {
-    function edd_widgets_pack_init() {
+	function edd_widgets_pack_init() {
 
-        if( ! function_exists( 'edd_price' ) )
-            return;
+		if ( ! function_exists( 'edd_price' ) ) {
+			return;
+		}
 
-        // load internationalization
-        load_plugin_textdomain( 'edd-widgets-pack', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+		// load internationalization.
+		load_plugin_textdomain( 'edd-widgets-pack', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
 
-        // Handle licensing
-        if( class_exists( 'EDD_License' ) ) {
-            $license = new EDD_License( __FILE__, 'Widgets Pack', '1.2.6', 'EDD Team' );
-        }
+		// Handle licensing.
+		if ( class_exists( 'EDD_License' ) ) {
+			$license = new EDD_License( __FILE__, 'Widgets Pack', '1.2.6', 'EDD Team' );
+		}
 
-        // register widgets
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-top-sellers.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-most-commented.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-most-recent.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-related-downloads.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-featured-download.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-random-download.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-archives.php' );
-        require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-downloads-calendar.php' );
-    }
+		// register widgets.
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-top-sellers.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-most-commented.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-most-recent.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-related-downloads.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-featured-download.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-random-download.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-archives.php' );
+		require_once( plugin_dir_path( __FILE__ ) . 'widgets/edd-widget-downloads-calendar.php' );
+	}
 }
 add_action( 'plugins_loaded', 'edd_widgets_pack_init' );

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -156,6 +156,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		/**
 		 * Form
 		 *
+		 * @param array $instance This widget's instance.
 		 * @return   void
 		 * @since    1.0
 		 */
@@ -164,12 +165,19 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 			$show_count = isset( $instance['show_count'] ) ? esc_attr( $instance['show_count'] ) : 0;
 			?>
 			<p>
-			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 			</p>
 			<p>
-			<input id="<?php echo $this->get_field_id( 'show_count' ); ?>" name="<?php echo $this->get_field_name( 'show_count' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
-			<label for="<?php echo $this->get_field_id( 'show_count' ); ?>"><?php printf( __('Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'show_count' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_count' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'show_count' ) ); ?>">
+				<?php
+				sprintf(
+					/* translators: the plural post type label */
+					__( 'Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true )
+				);
+				?>
+				</label>
 			</p>
 			<?php
 		}

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
 			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-			// contruct widget.
+			// construct widget.
 			parent::__construct( false, __( 'EDD Archives', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A monthly archive of your site\'s %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
 		}
 
@@ -60,7 +60,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 
 				// check if there is a title.
 				if ( $title ) {
-					// add the title to the ouput.
+					// add the title to the output.
 					$out .= $args['before_title'] . $title . $args['after_title'];
 				}
 

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -47,7 +47,8 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 */
 		public function widget( $args, $instance ) {
 
-			if ( false === $cache = get_transient( 'edd_widgets_archives' ) ) {
+			$cache = get_transient( 'edd_widgets_archives' );
+			if ( false === $cache ) {
 
 				// get the title and apply filters.
 				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -174,7 +174,8 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 				<?php
 				sprintf(
 					/* translators: the plural post type label */
-					__( 'Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					__( 'Show %s counts?', 'edd-widgets-pack' ),
+					edd_get_label_plural( true )
 				);
 				?>
 				</label>

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 					)
 				);
 
-				// remove .
+				// remove filter.
 				remove_filter( 'getarchives_where', array( &$this, 'getarchives_where_filter' ), 10, 2 );
 
 				remove_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -172,10 +172,10 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 				<input id="<?php echo esc_attr( $this->get_field_id( 'show_count' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_count' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'show_count' ) ); ?>">
 				<?php
-				sprintf(
+				printf(
 					/* translators: the plural post type label */
-					__( 'Show %s counts?', 'edd-widgets-pack' ),
-					edd_get_label_plural( true )
+					esc_html__( 'Show %s counts?', 'edd-widgets-pack' ),
+					esc_attr( edd_get_label_plural( true ) )
 				);
 				?>
 				</label>

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -44,8 +44,8 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 *
 		 * @return   void
 		 * @since    1.0
-		*/
-		function widget( $args, $instance ) {
+		 */
+		public function widget( $args, $instance ) {
 
 			if ( false === $cache = get_transient( 'edd_widgets_archives' ) ) {
 
@@ -106,7 +106,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @return   string
 		 * @since    1.0
 		 */
-		function getarchives_where_filter( $where, $r ) {
+		public function getarchives_where_filter( $where, $r ) {
 			return str_replace( "post_type = 'post'", "post_type = 'download'", $where );
 		}
 
@@ -117,7 +117,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @since 1.3
 		 * @return string
 		 */
-		function month_link( $monthlink, $year, $month ) {
+		public function month_link( $monthlink, $year, $month ) {
 			return $monthlink . '?post_type="download"';
 		}
 
@@ -127,7 +127,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -148,7 +148,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_archives' );
 		}
 
@@ -158,7 +158,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title      = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$show_count = isset( $instance['show_count'] ) ? esc_attr( $instance['show_count'] ) : 0;
 			?>

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 
 			if ( false === $cache = get_transient( 'edd_widgets_archives' ) ) {
 
-				// get the title and apply .
+				// get the title and apply filters.
 				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
 				// get show count boolean.
@@ -134,8 +134,7 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize show count.
-			$instance['show_count'] = ! empty( $new_instance['show_count'] ) ? strip_tags( $new_instance['show_count'] ) : '';
-			$instance['show_count'] = '1' === $instance['show_count'] ? 1 : 0;
+			$instance['show_count'] = ! empty( $new_instance['show_count'] ) && '1' === $new_instance['show_count'] ? 1 : 0;
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-archives.php
+++ b/widgets/edd-widget-archives.php
@@ -3,12 +3,11 @@
  * EDD Archives Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Archives Widget Class
@@ -18,175 +17,164 @@
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! class_exists( 'EDD_Archives' ) ) {
-    class EDD_Archives extends WP_Widget {
+	class EDD_Archives extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
+			// contruct widget.
+			parent::__construct( false, __( 'EDD Archives', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A monthly archive of your site\'s %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
-            // contruct widget
-            parent::__construct( false, __( 'EDD Archives', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A monthly archive of your site\'s %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		*/
+		function widget( $args, $instance ) {
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+			if ( false === $cache = get_transient( 'edd_widgets_archives' ) ) {
 
-        function widget( $args, $instance )
-        {
+				// get the title and apply .
+				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-           if ( false == $cache = get_transient( 'edd_widgets_archives' ) ) {
+				// get show count boolean.
+				$show_count = isset( $instance['show_count'] ) && 1 === $instance['show_count'] ? 1 : 0;
 
-                // get the title and apply filters
-                $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+				// start collecting the output.
+				$out = '';
 
-                // get show count boolean
-                $show_count = isset( $instance['show_count'] ) && $instance['show_count'] === 1 ? 1 : 0;
+				// check if there is a title.
+				if ( $title ) {
+					// add the title to the ouput.
+					$out .= $args['before_title'] . $title . $args['after_title'];
+				}
 
-                // start collecting the output
-                $out = "";
+				$out .= "<ul>\n";
 
-                // check if there is a title
-                if ( $title ) {
-                    // add the title to the ouput
-                    $out .= $args['before_title'] . $title . $args['after_title'];
-                }
+				// add download post type to archives.
+				add_filter( 'getarchives_where', array( &$this, 'getarchives_where_filter' ), 10, 2 );
 
-                $out .= "<ul>\n";
+				add_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
 
-                // add download post type to archives
-                add_filter( 'getarchives_where' , array( &$this, 'getarchives_where_filter' ) , 10 , 2 );
+				// output the archives.
+				$out .= wp_get_archives(
+					array(
+						'echo'            => 0,
+						'show_post_count' => $show_count,
+					)
+				);
 
-                add_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
+				// remove .
+				remove_filter( 'getarchives_where', array( &$this, 'getarchives_where_filter' ), 10, 2 );
 
-                // output the archives
-                $out .= wp_get_archives( array( 'echo' => 0, 'show_post_count' => $show_count ) );
+				remove_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
 
-                // remove filter
-                remove_filter( 'getarchives_where' , array( &$this, 'getarchives_where_filter' ), 10, 2 );
+				// finish the list.
+				$out .= "</ul>\n";
 
-                remove_filter( 'month_link', array( $this, 'month_link' ), 10, 3 );
+				// set the widget's containers.
+				$cache = $args['before_widget'] . $out . $args['after_widget'];
 
-                // finish the list
-                $out .= "</ul>\n";
+				// store the result on a temporal transient.
+				set_transient( 'edd_widgets_archives', $cache );
 
-                // set the widget's containers
-                $cache = $args['before_widget'] . $out . $args['after_widget'];
+			}
 
-                // store the result on a temporal transient
-                set_transient( 'edd_widgets_archives', $cache );
+			echo $cache;
 
-            }
-
-            echo $cache;
-
-        }
-
-
-        /**
-         * Get Archives Where Filter
-         *
-         * @return   string
-         * @since    1.0
-        */
-
-        function getarchives_where_filter( $where , $r )
-        {
-            return str_replace( "post_type = 'post'" , "post_type = 'download'" , $where );
-        }
+		}
 
 
-        /**
-         * Filters the month link so the links go to the
-         * date archives for the download post type.
-         *
-         * @since 1.3
-         * @return string
-         */
-        function month_link( $monthlink, $year, $month ) {
-            return $monthlink . '?post_type="download"';
-        }
+		/**
+		 * Get Archives Where Filter
+		 *
+		 * @return   string
+		 * @since    1.0
+		 */
+		function getarchives_where_filter( $where, $r ) {
+			return str_replace( "post_type = 'post'", "post_type = 'download'", $where );
+		}
 
+		/**
+		 * Filters the month link so the links go to the
+		 * date archives for the download post type.
+		 *
+		 * @since 1.3
+		 * @return string
+		 */
+		function month_link( $monthlink, $year, $month ) {
+			return $monthlink . '?post_type="download"';
+		}
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+			// sanitize show count.
+			$instance['show_count'] = ! empty( $new_instance['show_count'] ) ? strip_tags( $new_instance['show_count'] ) : '';
+			$instance['show_count'] = '1' === $instance['show_count'] ? 1 : 0;
 
-            // sanitize show price
-            $instance['show_count'] = strip_tags( $new_instance['show_count'] );
-            $instance['show_count'] = $instance['show_count'] === '1' ? 1 : 0;
+			// delete cache.
+			$this->delete_cache();
 
-            // delete cache
-            $this->delete_cache();
+			return $instance;
+		}
 
-            return $instance;
-        }
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			delete_transient( 'edd_widgets_archives' );
+		}
 
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title      = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$show_count = isset( $instance['show_count'] ) ? esc_attr( $instance['show_count'] ) : 0;
+			?>
+			<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+			</p>
+			<p>
+			<input id="<?php echo $this->get_field_id( 'show_count' ); ?>" name="<?php echo $this->get_field_name( 'show_count' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
+			<label for="<?php echo $this->get_field_id( 'show_count' ); ?>"><?php printf( __('Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+			</p>
+			<?php
+		}
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function delete_cache()
-        {
-            delete_transient( 'edd_widgets_archives' );
-        }
-
-
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $show_count = isset( $instance['show_count'] ) ? esc_attr( $instance['show_count'] ) : 0;
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_count' ); ?>" name="<?php echo $this->get_field_name( 'show_count' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_count ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_count' ); ?>"><?php printf( __('Show %s counts?', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                </p>
-            <?php
-        }
-
-    }
+	}
 }
 
 
@@ -199,8 +187,8 @@ if ( ! class_exists( 'EDD_Archives' ) ) {
 */
 
 if ( ! function_exists( 'edd_widgets_pack_register_archives_widget' ) ) {
-    function edd_widgets_pack_register_archives_widget() {
-        register_widget( 'EDD_Archives' );
-    }
+	function edd_widgets_pack_register_archives_widget() {
+		register_widget( 'EDD_Archives' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_archives_widget', 10 );

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -3,12 +3,11 @@
  * EDD Downloads Calendar Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Downloads Calendar Widget Class
@@ -18,311 +17,322 @@
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
-    class EDD_Downloads_Calendar extends WP_Widget {
+	class EDD_Downloads_Calendar extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
 
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-            // construct widget
-            parent::__construct( false, sprintf( __( 'EDD %s Calendar', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A calendar of your site\'s EDD %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
-
-
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function widget( $args, $instance )
-        {
-
-            // get the title and apply filters
-            $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
-
-            // set the limit
-            $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
-
-            // start collecting the output
-            $out = "";
-
-            // check if there is a title
-            if ( $title ) {
-                // add the title to the ouput
-                $out .= $args['before_title'] . $title . $args['after_title'];
-            }
-
-            $out .= $this->get_calendar();
-
-            // set the widget's containers
-            $out = $args['before_widget'] . $out . $args['after_widget'];
-
-            echo $out;
-
-        }
+			// construct widget.
+			parent::__construct( false, sprintf( __( 'EDD %s Calendar', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A calendar of your site\'s EDD %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
+			// get the title and apply filters.
+			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+			// set the limit.
+			$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-            // delete cache
-            $this->delete_cache();
+			// start collecting the output.
+			$out = '';
 
-            return $instance;
-        }
+			// check if there is a title.
+			if ( $title ) {
+				// add the title to the ouput.
+				$out .= $args['before_title'] . $title . $args['after_title'];
+			}
 
+			$out .= $this->get_calendar();
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */
+			// set the widget's containers.
+			$out = $args['before_widget'] . $out . $args['after_widget'];
 
-        function delete_cache()
-        {
-            // check if widget is active
-            if ( ! is_active_widget( false, false, $this->id_base, true ) )
-            return;
+			echo $out;
 
-            // delete this widget's transient
-            delete_transient( 'edd_widgets_downloads_calendar' );
-        }
+		}
 
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-            <?php
-        }
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
+
+			// delete cache.
+			$this->delete_cache();
+
+			return $instance;
+		}
 
 
-        /**
-         * Get Calendar
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			// check if widget is active.
+			if ( ! is_active_widget( false, false, $this->id_base, true ) ) {
+				return;
+			}
 
-        function get_calendar( $initial = true, $echo = true ) {
-            global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
+			// delete this widget's transient.
+			delete_transient( 'edd_widgets_downloads_calendar' );
+		}
 
-            $cache = array();
-            $key = md5( $m . $monthnum . $year );
 
-            if ( ! $posts ) {
-                $gotsome = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'download' AND post_status = 'publish' LIMIT 1" );
-                if ( ! $gotsome ) {
-                    $this->delete_cache();
-                    return;
-                }
-            }
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 
-            if ( isset( $_GET['w'] ) )
-                $w = ''.intval( $_GET['w'] );
+			?>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				</p>
+			<?php
+		}
 
-            // week_begins = 0 stands for Sunday
-            $week_begins = intval( get_option( 'start_of_week' ) );
 
-            // Let's figure out when we are
-            if ( ! empty( $monthnum ) && ! empty( $year ) ) {
-                $thismonth = ''.zeroise( intval( $monthnum ), 2 );
-                $thisyear = ''.intval( $year );
-            } elseif ( ! empty( $w ) ) {
-                // We need to get the month from MySQL
-                $thisyear = ''.intval( substr( $m, 0, 4 ) );
-                $d = ( ( $w - 1 ) * 7 ) + 6; //it seems MySQL's weeks disagree with PHP's
-                $thismonth = $wpdb->get_var( "SELECT DATE_FORMAT( ( DATE_ADD( '{$thisyear}0101', INTERVAL $d DAY ) ), '%m' )" );
-            } elseif ( ! empty( $m ) ) {
-                $thisyear = ''.intval( substr( $m, 0, 4 ) );
-                if ( strlen( $m ) < 6 )
-                        $thismonth = '01';
-                else
-                        $thismonth = ''.zeroise( intval( substr( $m, 4, 2 ) ), 2 );
-            } else {
-                $thisyear = gmdate( 'Y', current_time( 'timestamp' ) );
-                $thismonth = gmdate( 'm', current_time( 'timestamp' ) );
-            }
+		/**
+		 * Get Calendar
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function get_calendar( $initial = true, $echo = true ) {
+			global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
-            $unixmonth = mktime( 0, 0 , 0, $thismonth, 1, $thisyear );
-            $last_day = date( 't', $unixmonth );
+			$cache = array();
+			$key   = md5( $m . $monthnum . $year );
 
-            // Get the next and previous month and year with at least one download
-            $previous = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
-                FROM $wpdb->posts
-                WHERE post_date < '$thisyear-$thismonth-01'
-                AND post_type = 'download' AND post_status = 'publish'
-                    ORDER BY post_date DESC
-                    LIMIT 1" );
-            $next = $wpdb->get_row( "SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
-                FROM $wpdb->posts
-                WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
-                AND post_type = 'download' AND post_status = 'publish'
-                    ORDER BY post_date ASC
-                    LIMIT 1" );
+			if ( ! $posts ) {
+				$gotsome = $wpdb->get_var( "SELECT 1 as test FROM $wpdb->posts WHERE post_type = 'download' AND post_status = 'publish' LIMIT 1" );
+				if ( ! $gotsome ) {
+					$this->delete_cache();
+					return;
+				}
+			}
 
-            /* translators: Calendar caption: 1: month name, 2: 4-digit year */
-            $calendar_caption = _x( '%1$s %2$s', 'calendar caption' );
-            $calendar_output = '<table id="wp-calendar">
-            <caption>' . sprintf( $calendar_caption, $wp_locale->get_month( $thismonth ), date( 'Y', $unixmonth ) ) . '</caption>
-            <thead>
-            <tr>';
+			if ( isset( $_GET['w'] ) ) {
+				$w = '' . intval( $_GET['w'] );
+			}
 
-            $myweek = array();
+			// week_begins = 0 stands for Sunday.
+			$week_begins = intval( get_option( 'start_of_week' ) );
 
-            for ( $wdcount=0; $wdcount<=6; $wdcount++ ) {
-                $myweek[] = $wp_locale->get_weekday( ( $wdcount+$week_begins )%7 );
-            }
+			// Let's figure out when we are.
+			if ( ! empty( $monthnum ) && ! empty( $year ) ) {
+				$thismonth = '' . zeroise( intval( $monthnum ), 2 );
+				$thisyear = '' . intval( $year );
+			} elseif ( ! empty( $w ) ) {
+				// We need to get the month from MySQL.
+				$thisyear = '' . intval( substr( $m, 0, 4 ) );
+				$d        = ( ( $w - 1 ) * 7 ) + 6;
+				// it seems MySQL's weeks disagree with PHP's.
+				$thismonth = $wpdb->get_var( "SELECT DATE_FORMAT( ( DATE_ADD( '{$thisyear}0101', INTERVAL $d DAY ) ), '%m' )" );
+			} elseif ( ! empty( $m ) ) {
+				$thisyear = '' . intval( substr( $m, 0, 4 ) );
+				if ( strlen( $m ) < 6 ) {
+					$thismonth = '01';
+				} else {
+					$thismonth = '' . zeroise( intval( substr( $m, 4, 2 ) ), 2 );
+				}
+			} else {
+				$thisyear = gmdate( 'Y', current_time( 'timestamp' ) );
+				$thismonth = gmdate( 'm', current_time( 'timestamp' ) );
+			}
 
-            foreach ( $myweek as $wd ) {
-                $day_name = ( true == $initial ) ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
-                $wd = esc_attr( $wd );
-                $calendar_output .= "\n\t\t<th scope=\"col\" title=\"$wd\">$day_name</th>";
-            }
+			$unixmonth = mktime( 0, 0, 0, $thismonth, 1, $thisyear );
+			$last_day  = date( 't', $unixmonth );
 
-            $calendar_output .= '
-            </tr>
-            </thead>
+			// Get the next and previous month and year with at least one download.
+			$previous = $wpdb->get_row(
+				"SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+				FROM $wpdb->posts
+				WHERE post_date < '$thisyear-$thismonth-01'
+				AND post_type = 'download' AND post_status = 'publish'
+					ORDER BY post_date DESC
+					LIMIT 1"
+			);
+			$next = $wpdb->get_row(
+				"SELECT MONTH( post_date ) AS month, YEAR( post_date ) AS year
+				FROM $wpdb->posts
+				WHERE post_date > '$thisyear-$thismonth-{$last_day} 23:59:59'
+				AND post_type = 'download' AND post_status = 'publish'
+					ORDER BY post_date ASC
+					LIMIT 1"
+			);
 
-            <tfoot>
-            <tr>';
+			/* translators: Calendar caption: 1: month name, 2: 4-digit year */
+			$calendar_caption = _x( '%1$s %2$s', 'calendar caption' );
+			$calendar_output = '<table id="wp-calendar">
+			<caption>' . sprintf( $calendar_caption, $wp_locale->get_month( $thismonth ), date( 'Y', $unixmonth ) ) . '</caption>
+			<thead>
+			<tr>';
 
-            if ( $previous ) {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $previous->month ), date( 'Y', mktime( 0, 0 , 0, $previous->month, 1, $previous->year ) ), edd_get_label_plural( true ) ) ) . '">&laquo; ' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) . '</a></td>';
-            } else {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="prev" class="pad">&nbsp;</td>';
-            }
+			$myweek = array();
 
-            $calendar_output .= "\n\t\t".'<td class="pad">&nbsp;</td>';
+			for ( $wdcount=0; $wdcount <= 6; $wdcount++ ) {
+				$myweek[] = $wp_locale->get_weekday( ( $wdcount + $week_begins ) % 7 );
+			}
 
-            if ( $next ) {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $next->month ), date( 'Y', mktime( 0, 0 , 0, $next->month, 1, $next->year ) ), edd_get_label_plural( true ) ) ) . '">' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) . ' &raquo;</a></td>';
-            } else {
-                $calendar_output .= "\n\t\t".'<td colspan="3" id="next" class="pad">&nbsp;</td>';
-            }
+			foreach ( $myweek as $wd ) {
+				$day_name = ( true == $initial ) ? $wp_locale->get_weekday_initial( $wd ) : $wp_locale->get_weekday_abbrev( $wd );
+				$wd = esc_attr( $wd );
+				$calendar_output .= "\n\t\t<th scope=\"col\" title=\"$wd\">$day_name</th>";
+			}
 
-            $calendar_output .= '
-            </tr>
-            </tfoot>
+			$calendar_output .= '
+			</tr>
+			</thead>
 
-            <tbody>
-            <tr>';
+			<tfoot>
+			<tr>';
 
-            // Get days with posts
-            $dayswithposts = $wpdb->get_results( "SELECT DISTINCT DAYOFMONTH( post_date )
-                FROM $wpdb->posts WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
-                AND post_type = 'download' AND post_status = 'publish'
-                AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'", ARRAY_N );
-            if ( $dayswithposts ) {
-                foreach ( ( array ) $dayswithposts as $daywith ) {
-                    $daywithpost[] = $daywith[0];
-                }
-            } else {
-                $daywithpost = array();
-            }
+			if ( $previous ) {
+				$calendar_output .= "\n\t\t" . '<td colspan="3" id="prev"><a href="' . get_month_link( $previous->year, $previous->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $previous->month ), date( 'Y', mktime( 0, 0, 0, $previous->month, 1, $previous->year ) ), edd_get_label_plural( true ) ) ) . '">&laquo; ' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $previous->month ) ) . '</a></td>';
+			} else {
+				$calendar_output .= "\n\t\t" . '<td colspan="3" id="prev" class="pad">&nbsp;</td>';
+			}
 
-            if ( strpos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' ) !== false || stripos( $_SERVER['HTTP_USER_AGENT'], 'camino' ) !== false || stripos( $_SERVER['HTTP_USER_AGENT'], 'safari' ) !== false )
-                $ak_title_separator = "\n";
-            else
-                $ak_title_separator = ', ';
+			$calendar_output .= "\n\t\t" . '<td class="pad">&nbsp;</td>';
 
-            $ak_titles_for_day = array();
-            $ak_post_titles = $wpdb->get_results( "SELECT ID, post_title, DAYOFMONTH( post_date ) as dom "
-                ."FROM $wpdb->posts "
-                ."WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00' "
-                ."AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59' "
-                ."AND post_type = 'download' AND post_status = 'publish'"
-             );
-            if ( $ak_post_titles ) {
-                foreach ( ( array ) $ak_post_titles as $ak_post_title ) {
+			if ( $next ) {
+				$calendar_output .= "\n\t\t" . '<td colspan="3" id="next"><a href="' . get_month_link( $next->year, $next->month ) . '?post_type=download" title="' . esc_attr( sprintf( __( 'View %3$s for %1$s %2$s', 'edd-widgets-pack' ), $wp_locale->get_month( $next->month ), date( 'Y', mktime( 0, 0, 0, $next->month, 1, $next->year ) ), edd_get_label_plural( true ) ) ) . '">' . $wp_locale->get_month_abbrev( $wp_locale->get_month( $next->month ) ) . ' &raquo;</a></td>';
+			} else {
+				$calendar_output .= "\n\t\t" . '<td colspan="3" id="next" class="pad">&nbsp;</td>';
+			}
 
-                        $post_title = esc_attr( apply_filters( 'the_title', $ak_post_title->post_title, $ak_post_title->ID ) );
+			$calendar_output .= '
+			</tr>
+			</tfoot>
 
-                        if ( empty( $ak_titles_for_day['day_'.$ak_post_title->dom] ) )
-                            $ak_titles_for_day['day_'.$ak_post_title->dom] = '';
-                        if ( empty( $ak_titles_for_day["$ak_post_title->dom"] ) ) // first one
-                            $ak_titles_for_day["$ak_post_title->dom"] = $post_title;
-                        else
-                            $ak_titles_for_day["$ak_post_title->dom"] .= $ak_title_separator . $post_title;
-                }
-            }
+			<tbody>
+			<tr>';
 
-            // See how much we should pad in the beginning
-            $pad = calendar_week_mod( date( 'w', $unixmonth )-$week_begins );
-            if ( 0 != $pad )
-                $calendar_output .= "\n\t\t".'<td colspan="'. esc_attr( $pad ) .'" class="pad">&nbsp;</td>';
+			// Get days with posts.
+			$dayswithposts = $wpdb->get_results(
+				"SELECT DISTINCT DAYOFMONTH( post_date )
+				FROM $wpdb->posts WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00'
+				AND post_type = 'download' AND post_status = 'publish'
+				AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59'",
+				ARRAY_N
+			);
+			if ( $dayswithposts ) {
+				foreach ( (array) $dayswithposts as $daywith ) {
+					$daywithpost[] = $daywith[0];
+				}
+			} else {
+				$daywithpost = array();
+			}
 
-            $daysinmonth = intval( date( 't', $unixmonth ) );
-            for ( $day = 1; $day <= $daysinmonth; ++$day ) {
-                if ( isset( $newrow ) && $newrow )
-                    $calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
-                $newrow = false;
+			if ( strpos( $_SERVER['HTTP_USER_AGENT'], 'MSIE' ) !== false || stripos( $_SERVER['HTTP_USER_AGENT'], 'camino' ) !== false || stripos( $_SERVER['HTTP_USER_AGENT'], 'safari' ) !== false ) {
+				$ak_title_separator = "\n";
+			} else {
+				$ak_title_separator = ', ';
+			}
 
-                if ( $day == gmdate( 'j', current_time( 'timestamp' ) ) && $thismonth == gmdate( 'm', current_time( 'timestamp' ) ) && $thisyear == gmdate( 'Y', current_time( 'timestamp' ) ) )
-                    $calendar_output .= '<td id="today">';
-                else
-                    $calendar_output .= '<td>';
+			$ak_titles_for_day = array();
+			$ak_post_titles    = $wpdb->get_results(
+				"SELECT ID, post_title, DAYOFMONTH( post_date ) as dom "
+				. "FROM $wpdb->posts "
+				. "WHERE post_date >= '{$thisyear}-{$thismonth}-01 00:00:00' "
+				. "AND post_date <= '{$thisyear}-{$thismonth}-{$last_day} 23:59:59' "
+				. "AND post_type = 'download' AND post_status = 'publish'"
+			);
+			if ( $ak_post_titles ) {
+				foreach ( (array) $ak_post_titles as $ak_post_title ) {
 
-                if ( in_array( $day, $daywithpost ) ) // any posts today?
-                        $calendar_output .= '<a href="' . get_day_link( $thisyear, $thismonth, $day ) . '?post_type=download" title="' . esc_attr( $ak_titles_for_day[ $day ] ) . "\">$day</a>";
-                else
-                    $calendar_output .= $day;
-                $calendar_output .= '</td>';
+					$post_title = esc_attr( apply_filters( 'the_title', $ak_post_title->post_title, $ak_post_title->ID ) );
 
-                if ( 6 == calendar_week_mod( date( 'w', mktime( 0, 0 , 0, $thismonth, $day, $thisyear ) )-$week_begins ) )
-                    $newrow = true;
-            }
+					if ( empty( $ak_titles_for_day[ 'day_' . $ak_post_title->dom ] ) ) {
+						$ak_titles_for_day[ 'day_' . $ak_post_title->dom ] = '';
+					}
+					if ( empty( $ak_titles_for_day[ "$ak_post_title->dom" ] ) ) {
+						// first one.
+						$ak_titles_for_day[ "$ak_post_title->dom" ] = $post_title;
+					} else {
+						$ak_titles_for_day[ "$ak_post_title->dom" ] .= $ak_title_separator . $post_title;
+					}
+				}
+			}
 
-            $pad = 7 - calendar_week_mod( date( 'w', mktime( 0, 0 , 0, $thismonth, $day, $thisyear ) )-$week_begins );
-            if ( $pad != 0 && $pad != 7 )
-                $calendar_output .= "\n\t\t".'<td class="pad" colspan="'. esc_attr( $pad ) .'">&nbsp;</td>';
+			// See how much we should pad in the beginning.
+			$pad                  = calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
+			if ( 0 !== $pad ) {
+				$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
+			}
+			$daysinmonth = intval( date( 't', $unixmonth ) );
+			for ( $day = 1; $day <= $daysinmonth; ++$day ) {
+				if ( isset( $newrow ) && $newrow ) {
+					$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
+				}
+				$newrow = false;
 
-            $calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
+				if ( $day == gmdate( 'j', current_time( 'timestamp' ) ) && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
+					$calendar_output .= '<td id="today">';
+				} else {
+					$calendar_output .= '<td>';
+				}
+				if ( in_array( $day, $daywithpost ) ) {
+					// any posts today?
+						$calendar_output .= '<a href="' . get_day_link( $thisyear, $thismonth, $day ) . '?post_type=download" title="' . esc_attr( $ak_titles_for_day[ $day ] ) . "\">$day</a>";
+				} else {
+					$calendar_output .= $day;
+				}
+				$calendar_output .= '</td>';
 
-            return apply_filters( 'edd_widgets_pack_get_downloads_calendar',  $calendar_output );
+				if ( 6 === calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+					$newrow = true;
+				}
+			}
 
-        }
-    }
+			$pad                  = 7 - calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+			if ( 0 !== $pad && 7 !== $pad ) {
+				$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
+			}
+			$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
+
+			return apply_filters( 'edd_widgets_pack_get_downloads_calendar', $calendar_output );
+
+		}
+	}
 
 }
 
@@ -333,22 +343,23 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! function_exists( 'edd_widgets_pack_register_downloads_calendar_widget' ) ) {
-    function edd_widgets_pack_register_downloads_calendar_widget() {
+	function edd_widgets_pack_register_downloads_calendar_widget() {
 
-        // get the EDD archives constant
-        $archives = true;
-        if( defined( 'EDD_DISABLE_ARCHIVE' ) && EDD_DISABLE_ARCHIVE == true ) {
-            $archives = false;
-        }
+		// get the EDD archives constant.
+		$archives = true;
+		if ( defined( 'EDD_DISABLE_ARCHIVE' ) && EDD_DISABLE_ARCHIVE === true ) {
+			$archives = false;
+		}
 
-        // no archives? then nothing to do here
-        if ( $archives === false )
-        return;
+		// no archives? then nothing to do .
+		if ( false === $archives ) {
+			return;
+		}
 
-        register_widget( 'EDD_Downloads_Calendar' );
-    }
+		register_widget( 'EDD_Downloads_Calendar' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_downloads_calendar_widget', 10 );

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -134,7 +134,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function get_calendar( $initial = true, $echo = true ) {
+		private function get_calendar( $initial = true, $echo = true ) {
 			global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
 			$cache = array();

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -292,8 +292,8 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 				}
 			}
 
-			// See how much we should pad in the beginning.
-			$pad                  = calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
+			// See how much we should pad at the beginning of the month.
+			$pad = (int) calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
 			if ( 0 !== $pad ) {
 				$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 			}
@@ -317,12 +317,13 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 				}
 				$calendar_output .= '</td>';
 
-				if ( 6 === calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+				if ( 6 === (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
 					$newrow = true;
 				}
 			}
 
-			$pad                  = 7 - calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+			// See how much we should pad at the end of the month.
+			$pad = 7 - (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
 			if ( 0 !== $pad && 7 !== $pad ) {
 				$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 			}

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -294,6 +294,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 			// See how much we should pad at the beginning of the month.
 			$pad = (int) calendar_week_mod( date( 'w', $unixmonth ) - $week_begins );
+
 			if ( 0 !== $pad ) {
 				$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 			}
@@ -301,6 +302,8 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 			$daysinmonth = intval( date( 't', $unixmonth ) );
 
 			for ( $day = 1; $day <= $daysinmonth; ++$day ) {
+				$days_into_week = (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+
 				if ( isset( $newrow ) && $newrow ) {
 					$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
 				}
@@ -308,7 +311,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 				if ( (int) gmdate( 'j', current_time( 'timestamp' ) ) === $day && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
 					$calendar_output .= '<td id="today">';
-					// should we do something to the calendar date for today?  Bold?
+					// should we do something to the calendar date for today?  Make the border bold?
 				} else {
 					$calendar_output .= '<td>';
 				}
@@ -319,15 +322,15 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 					$calendar_output .= $day;
 				}
 				$calendar_output .= '</td>';
-
-				if ( 6 === (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins ) ) {
+				if ( 6 === (int) $days_into_week ) {
 					$newrow = true;
 				}
 			}
 
 			// See how much we should pad at the end of the month.
-			$pad = 7 - (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
-			if ( 0 !== $pad && 7 !== $pad ) {
+			$end_of_month_pad = 7 - (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
+
+			if ( 0 !== $end_of_month_pad && 7 !== $end_of_month_pad ) {
 				$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
 			}
 			$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -121,8 +121,8 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -121,7 +121,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 			<?php

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -28,8 +28,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -47,7 +46,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
 			// get the title and apply filters.
 			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
@@ -81,7 +80,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @since    1.0
 		 */
 
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -100,7 +99,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			// check if widget is active.
 			if ( ! is_active_widget( false, false, $this->id_base, true ) ) {
 				return;
@@ -117,7 +116,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 
 			?>

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -297,15 +297,18 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 			if ( 0 !== $pad ) {
 				$calendar_output .= "\n\t\t" . '<td colspan="' . esc_attr( $pad ) . '" class="pad">&nbsp;</td>';
 			}
+
 			$daysinmonth = intval( date( 't', $unixmonth ) );
+
 			for ( $day = 1; $day <= $daysinmonth; ++$day ) {
 				if ( isset( $newrow ) && $newrow ) {
 					$calendar_output .= "\n\t</tr>\n\t<tr>\n\t\t";
 				}
 				$newrow = false;
 
-				if ( gmdate( 'j', current_time( 'timestamp' ) ) === $day && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
+				if ( (int) gmdate( 'j', current_time( 'timestamp' ) ) === $day && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
 					$calendar_output .= '<td id="today">';
+					// should we do something to the calendar date for today?  Bold?
 				} else {
 					$calendar_output .= '<td>';
 				}

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -134,7 +134,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		private function get_calendar( $initial = true, $echo = true ) {
+		protected function get_calendar( $initial = true, $echo = true ) {
 			global $wpdb, $m, $monthnum, $year, $wp_locale, $posts;
 
 			$cache = array();

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -329,9 +329,8 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 
 			// See how much we should pad at the end of the month.
 			$end_of_month_pad = 7 - (int) calendar_week_mod( date( 'w', mktime( 0, 0, 0, $thismonth, $day, $thisyear ) ) - $week_begins );
-
 			if ( 0 !== $end_of_month_pad && 7 !== $end_of_month_pad ) {
-				$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $pad ) . '">&nbsp;</td>';
+				$calendar_output .= "\n\t\t" . '<td class="pad" colspan="' . esc_attr( $end_of_month_pad ) . '">&nbsp;</td>';
 			}
 			$calendar_output .= "\n\t</tr>\n\t</tbody>\n\t</table>";
 

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -354,7 +354,7 @@ if ( ! function_exists( 'edd_widgets_pack_register_downloads_calendar_widget' ) 
 			$archives = false;
 		}
 
-		// no archives? then nothing to do .
+		// no archives? then nothing to do here.
 		if ( false === $archives ) {
 			return;
 		}

--- a/widgets/edd-widget-downloads-calendar.php
+++ b/widgets/edd-widget-downloads-calendar.php
@@ -305,7 +305,7 @@ if ( ! class_exists( 'EDD_Downloads_Calendar' ) ) {
 				}
 				$newrow = false;
 
-				if ( $day == gmdate( 'j', current_time( 'timestamp' ) ) && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
+				if ( gmdate( 'j', current_time( 'timestamp' ) ) === $day && gmdate( 'm', current_time( 'timestamp' ) ) === $thismonth && gmdate( 'Y', current_time( 'timestamp' ) ) === $thisyear ) {
 					$calendar_output .= '<td id="today">';
 				} else {
 					$calendar_output .= '<td>';

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -203,31 +203,32 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 
 			?>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-				<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'download' ); ?>"><?php echo edd_get_label_singular(); ?>:</label>
-				<select name="<?php echo $this->get_field_name( 'download' ); ?>" id="<?php echo $this->get_field_id( 'download' ); ?>">
-				<?php if ( ! empty( $downloads ) ) {
+				<label for="<?php echo esc_attr( $this->get_field_id( 'download' ) ); ?>"><?php echo esc_attr( edd_get_label_singular() ); ?>:</label>
+				<select name="<?php echo esc_attr( $this->get_field_name( 'download' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'download' ) ); ?>">
+				<?php
+				if ( ! empty( $downloads ) ) {
 					foreach ( $downloads as $key => $download_details ) {
-						echo '<option value="' . $download_details['value'] . '" ' . selected( $download_details['value'], $download ) . '>' . $download_details['title'] . '</option>';
+						echo '<option value="' . esc_attr( $download_details['value'] ) . '" ' . selected( $download_details['value'], $download ) . '>' . esc_attr( $download_details['title'] ) . '</option>';
 					}
 				}
 				?>
 				</select>
 			</p>
 			<p>
-				<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-				<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+				<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-				<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label> 
+				<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-				<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<?php
 		}

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -104,7 +104,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 						$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 						// get the post .
-						if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+						if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 							$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 							$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
 							$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -161,11 +161,11 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			$instance['download'] = $new_instance['download'] ? $new_instance['download'] : 0;
 
 			// sanitize show price.
-			$instance['show_price'] = strip_tags( $new_instance['show_price'] );
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
 			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
 			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -228,7 +228,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<?php
 		}

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -168,7 +168,6 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// delete cache.
 			$this->delete_cache();
@@ -228,7 +227,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			</p>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-				<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 			</p>
 			<?php
 		}

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -167,7 +167,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -1,307 +1,290 @@
 <?php
-/** 
+/**
  * EDD Featured Download Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Featured Download Widget Class
  *
  * A featured EDD download.
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! class_exists( 'EDD_Featured_Download' ) ) {
-    class EDD_Featured_Download extends WP_Widget {
+	class EDD_Featured_Download extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
 
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            
-            parent::__construct( false, sprintf( __( 'EDD Featured %s', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A featured EDD %s.', 'edd-widgets-pack' ), edd_get_label_singular( true ) ) ) );
-        }
+			parent::__construct( false, sprintf( __( 'EDD Featured %s', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A featured EDD %s.', 'edd-widgets-pack' ), edd_get_label_singular( true ) ) ) );
+		}
 
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
-        function widget( $args, $instance )
-        {
+			if ( false == $cache = get_transient( 'edd_widgets_featured_download_' . $this->id ) ) {
 
-            if ( false == $cache = get_transient( 'edd_widgets_featured_download_' . $this->id ) ) {
+				// get the title and apply filters.
+				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-                // get the title and apply filters
-                $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+				// get the featured download.
+				$download = isset( $instance['download'] ) ? $instance['download'] : 0;
 
-                // get the featured download
-                $download = isset( $instance['download'] ) ? $instance['download'] : 0;
-                
-                // get show price boolean
-                $show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
+				// get show price boolean.
+				$show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
 
-                // get the thumbnail boolean
-                $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
+				// get the thumbnail boolean.
+				$thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
 
-                // set the thumbnail size
-                $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
+				// set the thumbnail size.
+				$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-                // start collecting the output
-                $out = "";
+				// start collecting the output.
+				$out = "";
 
-                // check if there is a title
-                if ( $title ) {
-                    // add the title to the ouput
-                    $out .= $args['before_title'] . $title . $args['after_title'];
-                }
+				// check if there is a title.
+				if ( $title ) {
+					// add the title to the ouput.
+					$out .= $args['before_title'] . $title . $args['after_title'];
+				}
 
-                // set the params
-                $params = array( 
-                    'post_type'      => 'download', 
-                    'posts_per_page' =>  1, 
-                    'post_status'    => 'publish', 
-                    'post__in'       =>  array( $download )
-                 );
+				// set the params.
+				$params = array(
+					'post_type'      => 'download',
+					'posts_per_page' => 1,
+					'post_status'    => 'publish',
+					'post__in'       => array( $download ),
+				);
 
-                // get featured download
-                $featured_download = get_posts( $params );
+				// get featured download.
+				$featured_download = get_posts( $params );
 
-                // check download
-                if ( is_null( $featured_download ) || empty( $featured_download ) ) {
-                    // return if there is no download
-                    return;
+				// check download.
+				if ( is_null( $featured_download ) || empty( $featured_download ) ) {
+					// return if there is no download.
+					return;
+				} else {
+					// start the list output.
+					$out .= "<ul class=\"widget-featured-download\">\n";
 
-                } else {
-                    // start the list output
-                    $out .= "<ul class=\"widget-featured-download\">\n";
+					// set the link structure.
+					$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-                    // set the link structure
-                    $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
-                   
-                    // filter the thumbnail size
-                    $thumbnail_size = apply_filters( 'edd_widgets_featured_download_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
-                    
-                    // loop trough the featured download
-                    foreach ( $featured_download as $download ) {
-                        // get the title 
-                        $title = apply_filters( 'the_title', $download->post_title, $download->ID );
-                        $title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
+					// filter the thumbnail size.
+					$thumbnail_size = apply_filters( 'edd_widgets_featured_download_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-                       // get the post thumbnail
-                       if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                           $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                           $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                           $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                       } else {
-                           $out .= "<li>\n";
-                       }
+					// loop trough the featured download.
+					foreach ( $featured_download as $download ) {
+						// get the title.
+						$title      = apply_filters( 'the_title', $download->post_title, $download->ID );
+						$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-                       // append the download's title
-                       $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
-                        
-                        // get the price
-                        if ( $show_price === 1 ) {
-                            if ( edd_has_variable_prices( $download->ID ) ) {
-                                $price = edd_price_range( $download->ID );
-                            } else {
-                                $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                            }
-                            $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price ); 
-                        }
-                        
-                        // finish this element
-                        $out .= "</li>\n";
-                    }
-                    // finish the list
-                    $out .= "</ul>\n";
-                }
+						// get the post .
+						if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+							$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+							$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
+							$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+						} else {
+							$out .= "<li>\n";
+						}
 
-                // set the widget's containers
-                $cache = $args['before_widget'] . $out . $args['after_widget'];
+						// append the downloads title.
+						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-                // store the result on a temporal transient
-                set_transient( 'edd_widgets_featured_download', $cache );
+						// get the price.
+						if ( 1 === $show_price ) {
+							if ( edd_has_variable_prices( $download->ID ) ) {
+								$price = edd_price_range( $download->ID );
+							} else {
+								$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+							}
+							$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+						}
 
-            }
+						// finish this element.
+						$out .= "</li>\n";
+					}
+						// finish the list.
+						$out .= "</ul>\n";
+				}
 
-            echo $cache;
+				// set the widget's containers.
+				$cache = $args['before_widget'] . $out . $args['after_widget'];
 
-        }
+				// store the result on a temporal transient.
+				set_transient( 'edd_widgets_featured_download', $cache );
+
+			}
+
+			echo $cache;
+
+		}
 
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+			// sanitize download.
+			$instance['download'] = strip_tags( $new_instance['download'] );
+			$instance['download'] = $new_instance['download'] ? $new_instance['download'] : 0;
 
-            // sanitize download
-            $instance['download'] = strip_tags( $new_instance['download'] );
-            $instance['download'] = $new_instance['download'] ? $new_instance['download'] : 0;
+			// sanitize show price.
+			$instance['show_price'] = strip_tags( $new_instance['show_price'] );
+			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
 
-            // sanitize show price
-            $instance['show_price'] = strip_tags( $new_instance['show_price'] );
-            $instance['show_price'] = $instance['show_price'] === '1' ? 1 : 0;
-            
-            // sanitize thumbnail
-            $instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
-            $instance['thumbnail'] = $instance['thumbnail'] === '1' ? 1 : 0;
+			// sanitize thumbnail.
+			$instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
+			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
 
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+			// sanitize thumbnail size.
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
-            // delete cache
-            $this->delete_cache();
+			// delete cache.
+			$this->delete_cache();
 
-            return $instance;
-        }
+			return $instance;
+		}
 
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */    
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			delete_transient( 'edd_widgets_featured_download' );
+		}
 
-        function delete_cache()
-        {            
-            delete_transient( 'edd_widgets_featured_download' );
-        }
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$download       = isset( $instance['download'] ) ? esc_attr( $instance['download'] ) : 0;
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
+			$downloads = $this->get_downloads();
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $download = isset( $instance['download'] ) ? esc_attr( $instance['download'] ) : 0;
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
-
-            $downloads = $this->get_downloads();
-
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'download' ); ?>"><?php echo edd_get_label_singular(); ?>:</label>
-                    <select name="<?php echo $this->get_field_name( 'download' ); ?>" id="<?php echo $this->get_field_id( 'download' ); ?>">
-                        <?php if ( ! empty( $downloads ) ) {
-                            foreach ( $downloads as $key => $download_details ) {
-                                echo '<option value="' . $download_details['value'] . '" ' . selected( $download_details['value'], $download ) . '>' . $download_details['title'] . '</option>';
-                            }
-                        } ?>
-                    </select>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-            <?php
-        }
+			?>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'download' ); ?>"><?php echo edd_get_label_singular(); ?>:</label>
+				<select name="<?php echo $this->get_field_name( 'download' ); ?>" id="<?php echo $this->get_field_id( 'download' ); ?>">
+				<?php if ( ! empty( $downloads ) ) {
+					foreach ( $downloads as $key => $download_details ) {
+						echo '<option value="' . $download_details['value'] . '" ' . selected( $download_details['value'], $download ) . '>' . $download_details['title'] . '</option>';
+					}
+				}
+				?>
+				</select>
+			</p>
+			<p>
+				<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+				<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+			</p>
+			<p>
+				<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+				<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label> 
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+				<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+			</p>
+			<?php
+		}
 
 
-        /**
-         * Get Downloads
-         *
-         * @return   array
-         * @since    1.0
-        */
+		/**
+		 * Get Downloads
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function get_downloads() {
+			// set the params.
+			$params = array( 
+				'post_type'      => 'download',
+				'posts_per_page' => -1,
+				'post_status'    => 'publish',
+			);
 
-        function get_downloads() 
-        {
-            // set the params
-             $params = array( 
-                 'post_type'      => 'download', 
-                 'posts_per_page' => -1, 
-                 'post_status'    => 'publish', 
-              );
+			// get all downloads.
+			$all_downloads = get_posts( $params );
 
-             // get all downloads
-             $all_downloads = get_posts( $params );
+			$result = array();
 
-             $result = array();
+			// check downloads.
+			if ( is_null( $all_downloads ) || empty( $all_downloads ) ) {
+				// return if there is no downloads.
+				return $result;
+			} else {
+				foreach ( $all_downloads as $download ) {
+					// get the title.
+					$result[] = array(
+						'value' => $download->ID,
+						'title' => apply_filters( 'the_title', $download->post_title, $download->ID ),
+					);
+				}
+			}
 
-             // check downloads
-             if ( is_null( $all_downloads ) || empty( $all_downloads ) ) {
-                 // return if there is no downloads
-                 return $result;
-             } else {
-                 foreach ( $all_downloads as $download ) {
-                     // get the title 
-                     $result[] = array( 
-                        'value' => $download->ID, 
-                        'title' => apply_filters( 'the_title', $download->post_title, $download->ID )
-                     );
-                 }
-
-             }
-
-             return $result;
-        }
-        
-    }
+			return $result;
+		}
+	}
 }
 
 
 /**
  * Register Featured Download Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
-
+ */
 if ( ! function_exists( 'edd_widgets_pack_register_featured_download_widget' ) ) {
-    function edd_widgets_pack_register_featured_download_widget() {
-        register_widget( 'EDD_Featured_Download' );
-    }
+	function edd_widgets_pack_register_featured_download_widget() {
+		register_widget( 'EDD_Featured_Download' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_featured_download_widget', 10 );

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -45,7 +45,8 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 */
 		public function widget( $args, $instance ) {
 
-			if ( false == $cache = get_transient( 'edd_widgets_featured_download_' . $this->id ) ) {
+			$cache = get_transient( 'edd_widgets_featured_download_' . $this->id );
+			if ( false === $cache ) {
 
 				// get the title and apply filters.
 				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -43,7 +43,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
 			if ( false == $cache = get_transient( 'edd_widgets_featured_download_' . $this->id ) ) {
 
@@ -150,7 +150,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -182,7 +182,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_featured_download' );
 		}
 
@@ -192,7 +192,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$download       = isset( $instance['download'] ) ? esc_attr( $instance['download'] ) : 0;
 			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
@@ -241,7 +241,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 */
 		function get_downloads() {
 			// set the params.
-			$params = array( 
+			$params = array(
 				'post_type'      => 'download',
 				'posts_per_page' => -1,
 				'post_status'    => 'publish',

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -239,7 +239,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function get_downloads() {
+		protected function get_downloads() {
 			// set the params.
 			$params = array(
 				'post_type'      => 'download',

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -227,7 +227,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<?php

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -111,7 +111,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 							$out .= "<li>\n";
 						}
 
-						// append the downloads title.
+						// append the download's title.
 						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
 						// get the price.
@@ -157,16 +157,13 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize download.
-			$instance['download'] = strip_tags( $new_instance['download'] );
-			$instance['download'] = $new_instance['download'] ? $new_instance['download'] : 0;
+			$instance['download'] = $new_instance['download'] ? strip_tags( $new_instance['download'] ) : 0;
 
 			// sanitize show price.
-			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
-			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
-			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );

--- a/widgets/edd-widget-featured-download.php
+++ b/widgets/edd-widget-featured-download.php
@@ -203,7 +203,7 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 
 			?>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 			</p>
 			<p>
@@ -220,14 +220,14 @@ if ( ! class_exists( 'EDD_Featured_Download' ) ) {
 			</p>
 			<p>
 				<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
 				<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnail?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<?php

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
 						// get the price.
-						if ( $show_price === 1 ) {
+						if ( 1 === $show_price ) {
 							if ( edd_has_variable_prices( $download->ID ) ) {
 								$price = edd_price_range( $download->ID );
 							} else {

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) );
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -173,7 +173,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) );
 
 			// delete cache.
 			$this->delete_cache();
@@ -220,7 +220,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 					);
 					?>
 					</label>
-					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
@@ -232,7 +232,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) );
+			$instance['limit'] = ! empty( $instance['limit'] ) ? (int) $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -65,7 +65,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 				$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;
 
 				// get the thumbnail boolean.
-				$thumbnail = isset( $instance['thumbnail'] ) &&1 === $instance['thumbnail'] ? 1 : 0;
+				$thumbnail = isset( $instance['thumbnail'] ) && 1 === $instance['thumbnail'] ? 1 : 0;
 
 				// set the thumbnail size.
 				$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ! empty( $instance['limit'] ) ? (int) $instance['limit'] : 4;
+			$instance['limit'] = isset( $instance['limit'] ) ? (int) $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $instance['limit'] : 4;
+			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -199,32 +199,39 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @since    1.0
 		 */
 		public function form( $instance ) {
-			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
 			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
 			?>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+					<label for="<?php esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php echo esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
+					<?php
+					sprintf(
+						/* translators: the plural post type label */
+						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					);
+					?>
+					</label>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -207,15 +207,16 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 
 			?>
 				<p>
-					<label for="<?php esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
 					<?php
-					sprintf(
+					printf(
 						/* translators: the plural post type label */
-						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+						esc_attr__( 'Number of %s to show:', 'edd-widgets-pack' ),
+						esc_attr( edd_get_label_plural( true ) )
 					);
 					?>
 					</label>
@@ -230,7 +231,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -164,7 +164,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = isset( $instance['limit'] ) ? (int) $instance['limit'] : 4;
+			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -165,7 +165,6 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 
 			// sanitize limit.
 			$instance['limit'] = strip_tags( $new_instance['limit'] );
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -175,7 +174,6 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// delete cache.
 			$this->delete_cache();
@@ -214,19 +212,19 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
 					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
-				</p>                
+				</p>
 				<p>
 					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
 					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -169,12 +169,10 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize show price.
-			$instance['show_price'] = ! empty( $instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
-			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = ! empty( $instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
-			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -28,8 +28,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -46,7 +45,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
 			// check if comments have been activated for EDD Downloads.
 			if ( ! post_type_supports( 'download', 'comments' ) ) {
@@ -158,7 +157,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -191,7 +190,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_most_commented' );
 		}
 
@@ -201,7 +200,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
 			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -207,7 +207,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 
 			?>
 				<p>
-					<label for="<?php esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php echo esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
@@ -223,14 +223,14 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -111,7 +111,7 @@ if ( ! class_exists( 'EDD_Most_Commented' ) ) {
 						$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 						// get the post thumbnail.
-						if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+						if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 							$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 							$out .= "<li class=\"widget-download-with-thumbnail\">\n";
 							$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-most-commented.php
+++ b/widgets/edd-widget-most-commented.php
@@ -1,265 +1,254 @@
 <?php
-/** 
+/**
  * EDD Most Commented Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Most Commented Widget Class
  *
  * A list of EDD most commented downloads.
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! class_exists( 'EDD_Most_Commented' ) ) {
-    class EDD_Most_Commented extends WP_Widget {
+	class EDD_Most_Commented extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
 
-        function __construct()
-        {   
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-            // contruct widget
-            parent::__construct( false, __( 'EDD Most Commented', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD most commented %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
+			// contruct widget.
+			parent::__construct( false, __( 'EDD Most Commented', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD most commented %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+			// check if comments have been activated for EDD Downloads.
+			if ( ! post_type_supports( 'download', 'comments' ) ) {
+				return;
+			}
 
-        function widget( $args, $instance )
-        {
-            
-            // check if comments have been activated for EDD Downloads
-            if ( ! post_type_supports( 'download', 'comments' ) )
-            return;
+			if ( false == $cache = get_transient( 'edd_widgets_most_commented' ) ) {
 
-            if ( false == $cache = get_transient( 'edd_widgets_most_commented' ) ) {
+				// get the title and apply filters.
+				$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-                // get the title and apply filters
-                $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+				// set the limit.
+				$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-                // set the limit 
-                $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4; 
-                
-                // get show price boolean
-                $show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
+				// get show price boolean.
+				$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;
 
-                // get the thumbnail boolean
-                $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
+				// get the thumbnail boolean.
+				$thumbnail = isset( $instance['thumbnail'] ) &&1 === $instance['thumbnail'] ? 1 : 0;
 
-                // set the thumbnail size
-                $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
+				// set the thumbnail size.
+				$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-                // start collecting the output
-                $out = "";
+				// start collecting the output.
+				$out = '';
 
-                // check if there is a title
-                if ( $title ) {
-                    // add the title to the ouput
-                    $out .= $args['before_title'] . $title . $args['after_title'];
-                }
+				// check if there is a title.
+				if ( $title ) {
+					// add the title to the ouput.
+					$out .= $args['before_title'] . $title . $args['after_title'];
+				}
 
-                // set the params
-                $params = array( 
-                    'post_type'      => 'download', 
-                    'posts_per_page' => $limit, 
-                    'post_status'    => 'publish', 
-                    'orderby'        => 'comment_count', 
-                 );
+				// set the params.
+				$params = array(
+					'post_type'      => 'download',
+					'posts_per_page' => $limit,
+					'post_status'    => 'publish',
+					'orderby'        => 'comment_count',
+				);
 
-                // get the most commented downloads
-                $most_commented = get_posts( $params );
+				// get the most commented downloads.
+				$most_commented = get_posts( $params );
 
-                // check the downloads
-                if ( is_null( $most_commented ) || empty( $most_commented ) ) {
-                    // return if there are no downloads
-                    return;
+				// check the downloads.
+				if ( is_null( $most_commented ) || empty( $most_commented ) ) {
+					// return if there are no downloads.
+					return;
 
-                } else {
-                    // start the list output
-                    $out .= "<ul class=\"widget-most-commented\">\n";
+				} else {
+					// start the list output.
+					$out .= "<ul class=\"widget-most-commented\">\n";
 
-                    // set the link structure
-                    $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
-                    
-                    // filter the thumbnail size
-                    $thumbnail_size = apply_filters( 'edd_widgets_most_commented_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
+					// set the link structure.
+					$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-                    // loop trough all downloads
-                    foreach ( $most_commented as $download ) {
-                        // get the title 
-                        $title = apply_filters( 'the_title', $download->post_title, $download->ID );
+					// filter the thumbnail size.
+					$thumbnail_size = apply_filters( 'edd_widgets_most_commented_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
+
+					// loop trough all downloads.
+					foreach ( $most_commented as $download ) {
+						// get the title.
+						$title = apply_filters( 'the_title', $download->post_title, $download->ID );
 						$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-                        // get the post thumbnail
-                        if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                            $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                            $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                            $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                        } else {
-                            $out .= "<li>\n";
-                        }
+						// get the post thumbnail.
+						if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+							$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+							$out .= "<li class=\"widget-download-with-thumbnail\">\n";
+							$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+						} else {
+							$out .= "<li>\n";
+						}
 
-                        // append the download's title
-                        $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
-                        
-                        // get the price
-                        if ( $show_price === 1 ) {
-                            if ( edd_has_variable_prices( $download->ID ) ) {
-                                $price = edd_price_range( $download->ID );
-                            } else {
-                                $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                            }
-                            $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price ); 
-                        }
-                        
-                        // finish this element
-                        $out .= "</li>\n";
-                    }
-                    // finish the list
-                    $out .= "</ul>\n";
-                }
+						// append the download's title.
+						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-                // set the widget's containers
-                $cache = $args['before_widget'] . $out . $args['after_widget'];
+						// get the price.
+						if ( $show_price === 1 ) {
+							if ( edd_has_variable_prices( $download->ID ) ) {
+								$price = edd_price_range( $download->ID );
+							} else {
+								$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+							}
+							$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+						}
 
-                // store the result on a temporal transient
-                set_transient( 'edd_widgets_most_commented', $cache );
+						// finish this element.
+						$out .= "</li>\n";
+					}
+					// finish the list.
+					$out .= "</ul>\n";
+				}
 
-            }
+				// set the widget's containers.
+				$cache = $args['before_widget'] . $out . $args['after_widget'];
 
-            echo $cache;
+				// store the result on a temporal transient.
+				set_transient( 'edd_widgets_most_commented', $cache );
 
-        }
+			}
 
+			echo $cache;
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+		}
 
-        function update( $new_instance, $old_instance )
-        {     
-            $instance = $old_instance;
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
 
-            // sanitize limit
-            $instance['limit'] = strip_tags( $new_instance['limit'] );
-            $instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
+			// sanitize limit.
+			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
-            // sanitize show price
-            $instance['show_price'] = strip_tags( $new_instance['show_price'] );
-            $instance['show_price'] = $instance['show_price'] === '1' ? 1 : 0;
-            
-            // sanitize thumbnail
-            $instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
-            $instance['thumbnail'] = $instance['thumbnail'] === '1' ? 1 : 0;
+			// sanitize show price.
+			$instance['show_price'] = ! empty( $instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
+			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
 
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+			// sanitize thumbnail.
+			$instance['thumbnail'] = ! empty( $instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
+			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
 
-            // delete cache
-            $this->delete_cache();
+			// sanitize thumbnail size.
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
-            return $instance;
-        }
+			// delete cache.
+			$this->delete_cache();
+
+			return $instance;
+		}
 
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */    
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			delete_transient( 'edd_widgets_most_commented' );
+		}
 
-        function delete_cache()
-        {
-            delete_transient( 'edd_widgets_most_commented' );
-        }
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+			?>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+				</p>                
+				<p>
+					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				</p>
+			<?php
+		}
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;            
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
-
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
-                </p>                
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-            <?php
-        }
-
-    }
+	}
 }
 
 
 /**
  * Register Most Commented Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
 */
 
 if ( ! function_exists( 'edd_widgets_pack_register_most_commented_widget' ) ) {
-    function edd_widgets_pack_register_most_commented_widget() {
-        register_widget( 'EDD_Most_Commented' );
-    }
+	function edd_widgets_pack_register_most_commented_widget() {
+		register_widget( 'EDD_Most_Commented' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_most_commented_widget', 10 );

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -45,7 +45,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
 			// get the title and apply filters.
 			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
@@ -156,7 +156,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -196,7 +196,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_most_recent' );
 		}
 
@@ -207,7 +207,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$offset         = isset( $instance['offset'] ) ? esc_attr( $instance['offset'] ) : 0;
 			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 					// get the post thumbnail.
-					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+					if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 						$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
 						$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -163,10 +163,10 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
 
 			// sanitize offset.
-			$instance['offset'] = strip_tags( $new_instance['offset'] );
+			$instance['offset'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['offset'] ) );
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -175,7 +175,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
 
 			// sanitize category.
 			$instance['category'] = $new_instance['category'] ? strip_tags( $new_instance['category'] ) : 'edd-all-categories';
@@ -230,7 +230,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				);
 				?>
 				</label>
-				<input type="number" min="0" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'offset' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'offset' ) ); ?>" type="text" value="<?php echo esc_html( $offset ); ?>"/>
+				<input type="number" min="0" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'offset' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'offset' ) ); ?>" value="<?php echo esc_html( $offset ); ?>"/>
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
@@ -254,7 +254,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'category' ) ); ?>">

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -171,20 +171,17 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['offset'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['offset'] ) ) ? $instance['offset'] : 4;
 
 			// sanitize show price.
-			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
-			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
-			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
 			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// sanitize category.
-			$instance['category'] = strip_tags( $new_instance['category'] );
-			$instance['category'] = $instance['category'] ? $instance['category'] : 'edd-all-categories';
+			$instance['category'] = $new_instance['category'] ? strip_tags( $new_instance['category'] ) : 'edd-all-categories';
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -163,10 +163,10 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
+			$instance['limit'] = ! empty( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize offset.
-			$instance['offset'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['offset'] ) );
+			$instance['offset'] = ! empty( $new_instance['offset'] ) ? (int) $new_instance['offset'] : 0;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -217,36 +217,59 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 
 			?>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-				<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html__( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'offset' ); ?>"><?php printf( __('Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-				<input type="number" min="0" size="3" id="<?php echo $this->get_field_id( 'offset' ); ?>" name="<?php echo $this->get_field_name( 'offset' ); ?>" type="text" value="<?php echo $offset; ?>"/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'offset' ) ); ?>">
+				<?php
+				sprintf(
+					/* translators: The plural post type label */
+					__( 'Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+				);
+				?>
+				</label>
+				<input type="number" min="0" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'offset' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'offset' ) ); ?>" type="text" value="<?php echo esc_html( $offset ); ?>"/>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-				<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
+				<?php
+				sprintf(
+					/* translators: the plural post type label */
+					__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+				);
+				?>
+				</label>
+				<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
 			</p>
 			<p>
-				<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-				<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-				<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+				<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-				<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'category' ); ?>"><?php printf( __( 'Display %s from category:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-				<select class="widefat" name="<?php echo $this->get_field_name( 'category' ); ?>" id="<?php echo $this->get_field_id( 'category' ); ?>">
-				<option value="edd-all-categories"><?php _e( 'All', 'edd-widgets-pack' ); ?></option>
-				<?php if( !empty( $category_list ) ) {
+				<label for="<?php echo esc_attr( $this->get_field_id( 'category' ) ); ?>">
+				<?php
+				sprintf(
+					/* translators: the plural post type label */
+					__( 'Display %s from category:', 'edd-widgets-pack' ),
+					edd_get_label_plural( true )
+				);
+				?>
+				</label>
+				<select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'category' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'category' ) ); ?>">
+				<option value="edd-all-categories"><?php esc_attr__( 'All', 'edd-widgets-pack' ); ?></option>
+				<?php
+				if ( ! empty( $category_list ) ) {
 					foreach ( $category_list as $key => $category_details ) {
-						echo '<option value="' . $category_details->slug . '"' . selected( $category_details->slug, $category ) . '>' . $category_details->name . '</option>';
+						echo '<option value="' . esc_attr( $category_details->slug ) . '"' . selected( $category_details->slug, $category ) . '>' . esc_attr( $category_details->name ) . '</option>';
 					}
 				}
 				?>

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -242,7 +242,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				);
 				?>
 				</label>
-				<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
+				<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" value="<?php echo esc_html( $limit ); ?>"/>
 			</p>
 			<p>
 				<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ! empty( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
+			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize offset.
 			$instance['offset'] = ! empty( $new_instance['offset'] ) ? (int) $new_instance['offset'] : 0;

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -217,7 +217,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 
 			?>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html__( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 				<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 			</p>
 			<p>
@@ -225,7 +225,8 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				<?php
 				sprintf(
 					/* translators: The plural post type label */
-					__( 'Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					__( 'Number of %s to skip:', 'edd-widgets-pack' ),
+					edd_get_label_plural( true )
 				);
 				?>
 				</label>
@@ -236,7 +237,8 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				<?php
 				sprintf(
 					/* translators: the plural post type label */
-					__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					__( 'Number of %s to show:', 'edd-widgets-pack' ),
+					edd_get_label_plural( true )
 				);
 				?>
 				</label>
@@ -244,14 +246,14 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			</p>
 			<p>
 				<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
 				<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<p>
@@ -265,7 +267,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				?>
 				</label>
 				<select class="widefat" name="<?php echo esc_attr( $this->get_field_name( 'category' ) ); ?>" id="<?php echo esc_attr( $this->get_field_id( 'category' ) ); ?>">
-				<option value="edd-all-categories"><?php esc_attr__( 'All', 'edd-widgets-pack' ); ?></option>
+				<option value="edd-all-categories"><?php esc_html_e( 'All', 'edd-widgets-pack' ); ?></option>
 				<?php
 				if ( ! empty( $category_list ) ) {
 					foreach ( $category_list as $key => $category_details ) {

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -164,11 +164,9 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 
 			// sanitize limit.
 			$instance['limit'] = strip_tags( $new_instance['limit'] );
-			$instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize offset.
 			$instance['offset'] = strip_tags( $new_instance['offset'] );
-			$instance['offset'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['offset'] ) ) ? $instance['offset'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -178,7 +176,6 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// sanitize category.
 			$instance['category'] = $new_instance['category'] ? strip_tags( $new_instance['category'] ) : 'edd-all-categories';
@@ -225,11 +222,11 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			</p>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'offset' ); ?>"><?php printf( __('Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-				<input class="small" size="3" id="<?php echo $this->get_field_id( 'offset' ); ?>" name="<?php echo $this->get_field_name( 'offset' ); ?>" type="text" value="<?php echo $offset; ?>"/>
+				<input type="number" min="0" size="3" id="<?php echo $this->get_field_id( 'offset' ); ?>" name="<?php echo $this->get_field_name( 'offset' ); ?>" type="text" value="<?php echo $offset; ?>"/>
 			</p>
 			<p>
-				<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-				<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+				<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+				<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
 			</p>
 			<p>
 				<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
@@ -241,7 +238,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			</p>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-				<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 			</p>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'category' ); ?>"><?php printf( __( 'Display %s from category:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -3,12 +3,11 @@
  * EDD Most Recent Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Most Recent Widget Class
@@ -18,262 +17,250 @@
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! class_exists( 'EDD_Most_Recent' ) ) {
-    class EDD_Most_Recent extends WP_Widget {
+	class EDD_Most_Recent extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
+			// contruct widget.
+			parent::__construct( false, __( 'EDD Most Recent', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD most recent %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
-            // contruct widget
-            parent::__construct( false, __( 'EDD Most Recent', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD most recent %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
+			// get the title and apply filters.
+			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+			// get the offset.
+			$offset = $instance['offset'] ? $instance['offset'] : 0;
 
-        function widget( $args, $instance ) {
+			// set the limit.
+			$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-            // get the title and apply filters
-            $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+			// get show price boolean.
+			$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;
 
-            // get the offset
-            $offset = $instance['offset'] ? $instance['offset'] : 0;
+			// get the thumbnail boolean.
+			$thumbnail = isset( $instance['thumbnail'] ) && 1 === $instance['thumbnail'] ? 1 : 0;
 
-            // set the limit
-            $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
+			// set the thumbnail size.
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-            // get show price boolean
-            $show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
+			// get the category.
+			$category = isset( $instance['category'] ) ? $instance['category'] : 'edd-all-categories';
 
-            // get the thumbnail boolean
-            $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
+			// start collecting the output.
+			$out = '';
 
-            // set the thumbnail size
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
+			// check if there is a title.
+			if ( $title ) {
+				// add the title to the ouput.
+				$out .= $args['before_title'] . $title . $args['after_title'];
+			}
 
-            // get the category
-            $category = isset( $instance['category'] ) ? $instance['category'] : 'edd-all-categories';
+			// set the params.
+			$params = array(
+				'post_type'      => 'download',
+				'posts_per_page' => absint( $limit ),
+				'post_status'    => 'publish',
+				'orderby'        => 'date',
+				'offset'         => absint( $offset ),
+			);
 
-            // start collecting the output
-            $out = "";
+			// adjust params if we're only pulling one category.
+			if ( isset( $category ) && 'edd-all-categories' !== $category ) {
+				$params['tax_query'][] = array(
+					'taxonomy' => 'download_category',
+					'field'    => 'slug',
+					'terms'    => $category,
+				);
+			}
 
-            // check if there is a title
-            if ( $title ) {
-                // add the title to the ouput
-                $out .= $args['before_title'] . $title . $args['after_title'];
-            }
+			$most_recent = get_posts( $params );
 
-            // set the params
-            $params = array(
-                'post_type'      => 'download',
-                'posts_per_page' => absint( $limit ),
-                'post_status'    => 'publish',
-                'orderby'        => 'date',
-                'offset'         => absint( $offset )
-             );
+			// check the downloads.
+			if ( is_null( $most_recent ) || empty( $most_recent ) ) {
+				// return if there are no downloads.
+				return;
+			} else {
+				// start the list output.
+				$out .= "<ul class=\"widget-most-recent\">\n";
 
-            // adjust params if we're only pulling one category
-            if( isset( $category ) && $category != 'edd-all-categories' ) {
-                $params['tax_query'][] = array(
-                    'taxonomy'       => 'download_category',
-                    'field'          => 'slug',
-                    'terms'          => $category
-                );
-            }
+				// set the link structure.
+				$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-            $most_recent = get_posts( $params );
+				// filter the thumbnail size.
+				$thumbnail_size = apply_filters( 'edd_widgets_most_recent_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-            // check the downloads
-            if ( is_null( $most_recent ) || empty( $most_recent ) ) {
-                // return if there are no downloads
-                return;
+				// loop trough all downloads.
+				foreach ( $most_recent as $download ) {
+					// get the title.
+					$title      = apply_filters( 'the_title', $download->post_title, $download->ID );
+					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-            } else {
-                // start the list output
-                $out .= "<ul class=\"widget-most-recent\">\n";
+					// get the post thumbnail.
+					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+						$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
+						$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+					} else {
+						$out .= "<li>\n";
+					}
 
-                // set the link structure
-                $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
+					// append the download's title.
+					$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-                // filter the thumbnail size
-                $thumbnail_size = apply_filters( 'edd_widgets_most_recent_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
+					// get the price.
+					if ( 1 === $show_price ) {
+						if ( edd_has_variable_prices( $download->ID ) ) {
+							$price = edd_price_range( $download->ID );
+						} else {
+							$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+						}
+						$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+					}
 
-                // loop trough all downloads
-                foreach ( $most_recent as $download ) {
-                    // get the title
-                    $title = apply_filters( 'the_title', $download->post_title, $download->ID );
-                    $title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
+					// finish this element.
+					$out .= "</li>\n";
+				}
+					// finish the list.
+					$out .= "</ul>\n";
+			}
 
-                    // get the post thumbnail
-                    if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                        $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                        $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                        $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                    } else {
-                        $out .= "<li>\n";
-                    }
+					// set the widget's containers.
+					echo $args['before_widget'] . $out . $args['after_widget'];
+		}
 
-                    // append the download's title
-                    $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-                    // get the price
-                    if ( $show_price === 1 ) {
-                        if ( edd_has_variable_prices( $download->ID ) ) {
-                            $price = edd_price_range( $download->ID );
-                        } else {
-                            $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                        }
-                        $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
-                    }
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
 
-                    // finish this element
-                    $out .= "</li>\n";
-                }
-                // finish the list
-                $out .= "</ul>\n";
-            }
+			// sanitize limit.
+			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
-            // set the widget's containers
-            echo $args['before_widget'] . $out . $args['after_widget'];
-        }
+			// sanitize offset.
+			$instance['offset'] = strip_tags( $new_instance['offset'] );
+			$instance['offset'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['offset'] ) ) ? $instance['offset'] : 4;
 
+			// sanitize show price.
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
+			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+			// sanitize thumbnail.
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
+			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
 
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
+			// sanitize thumbnail size.
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+			// sanitize category.
+			$instance['category'] = strip_tags( $new_instance['category'] );
+			$instance['category'] = $instance['category'] ? $instance['category'] : 'edd-all-categories';
 
-            // sanitize limit
-            $instance['limit'] = strip_tags( $new_instance['limit'] );
-            $instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
+			// delete cache.
+			$this->delete_cache();
 
-            // sanitize offset
-            $instance['offset'] = strip_tags( $new_instance['offset'] );
-            $instance['offset'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['offset'] ) ) ? $instance['offset'] : 4;
-
-            // sanitize show price
-            $instance['show_price'] = strip_tags( $new_instance['show_price'] );
-            $instance['show_price'] = $instance['show_price'] === '1' ? 1 : 0;
-
-            // sanitize thumbnail
-            $instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
-            $instance['thumbnail'] = $instance['thumbnail'] === '1' ? 1 : 0;
-
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
-
-            // sanitize category
-            $instance['category'] = strip_tags( $new_instance['category'] );
-            $instance['category'] = $instance['category'] ? $instance['category'] : 'edd-all-categories';
-
-            // delete cache
-            $this->delete_cache();
-
-            return $instance;
-        }
+			return $instance;
+		}
 
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function delete_cache()
-        {
-            delete_transient( 'edd_widgets_most_recent' );
-        }
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			delete_transient( 'edd_widgets_most_recent' );
+		}
 
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$offset         = isset( $instance['offset'] ) ? esc_attr( $instance['offset'] ) : 0;
+			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
+			$category       = isset( $instance['category'] ) ? esc_attr( $instance['category'] ) : 'all';
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $offset = isset( $instance['offset'] ) ? esc_attr( $instance['offset'] ) : 0;
-            $limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
-            $category = isset( $instance['category'] ) ? esc_attr( $instance['category'] ) : 'all';
+			$category_list = get_terms( 'download_category' );
 
-            $category_list = get_terms( 'download_category' );
-
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'offset' ); ?>"><?php printf( __('Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <input class="small" size="3" id="<?php echo $this->get_field_id( 'offset' ); ?>" name="<?php echo $this->get_field_name( 'offset' ); ?>" type="text" value="<?php echo $offset; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'category' ); ?>"><?php printf( __( 'Display %s from category:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <select class="widefat" name="<?php echo $this->get_field_name( 'category' ); ?>" id="<?php echo $this->get_field_id( 'category' ); ?>">
-                        <option value="edd-all-categories"><?php _e( 'All', 'edd-widgets-pack' ); ?></option>
-                        <?php if( !empty( $category_list ) ) {
-                            foreach( $category_list as $key => $category_details ) {
-                                echo '<option value="' . $category_details->slug . '"' . selected( $category_details->slug, $category ) . '>' . $category_details->name . '</option>';
-                            }
-                        } ?>
-                    </select>
-                </p>
-            <?php
-        }
-
-    }
+			?>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'offset' ); ?>"><?php printf( __('Number of %s to skip:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+				<input class="small" size="3" id="<?php echo $this->get_field_id( 'offset' ); ?>" name="<?php echo $this->get_field_name( 'offset' ); ?>" type="text" value="<?php echo $offset; ?>"/>
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+				<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+			</p>
+			<p>
+				<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+				<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
+			</p>
+			<p>
+				<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+				<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+			</p>
+			<p>
+				<label for="<?php echo $this->get_field_id( 'category' ); ?>"><?php printf( __( 'Display %s from category:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+				<select class="widefat" name="<?php echo $this->get_field_name( 'category' ); ?>" id="<?php echo $this->get_field_id( 'category' ); ?>">
+				<option value="edd-all-categories"><?php _e( 'All', 'edd-widgets-pack' ); ?></option>
+				<?php if( !empty( $category_list ) ) {
+					foreach ( $category_list as $key => $category_details ) {
+						echo '<option value="' . $category_details->slug . '"' . selected( $category_details->slug, $category ) . '>' . $category_details->name . '</option>';
+					}
+				}
+				?>
+				</select>
+			</p>
+			<?php
+		}
+	}
 }
 
 
@@ -283,11 +270,11 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! function_exists( 'edd_widgets_pack_register_most_recent_widget' ) ) {
-    function edd_widgets_pack_register_most_recent_widget() {
-        register_widget( 'EDD_Most_Recent' );
-    }
+	function edd_widgets_pack_register_most_recent_widget() {
+		register_widget( 'EDD_Most_Recent' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_most_recent_widget', 10 );

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -223,10 +223,10 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'offset' ) ); ?>">
 				<?php
-				sprintf(
+				printf(
 					/* translators: The plural post type label */
-					__( 'Number of %s to skip:', 'edd-widgets-pack' ),
-					edd_get_label_plural( true )
+					esc_attr__( 'Number of %s to skip:', 'edd-widgets-pack' ),
+					esc_attr( edd_get_label_plural( true ) )
 				);
 				?>
 				</label>
@@ -235,10 +235,10 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
 				<?php
-				sprintf(
+				printf(
 					/* translators: the plural post type label */
-					__( 'Number of %s to show:', 'edd-widgets-pack' ),
-					edd_get_label_plural( true )
+					esc_attr__( 'Number of %s to show:', 'edd-widgets-pack' ),
+					esc_attr( edd_get_label_plural( true ) )
 				);
 				?>
 				</label>
@@ -253,16 +253,16 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 			</p>
 			<p>
-				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+				<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 				<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 			</p>
 			<p>
 				<label for="<?php echo esc_attr( $this->get_field_id( 'category' ) ); ?>">
 				<?php
-				sprintf(
+				printf(
 					/* translators: the plural post type label */
-					__( 'Display %s from category:', 'edd-widgets-pack' ),
-					edd_get_label_plural( true )
+					esc_html__( 'Display %s from category:', 'edd-widgets-pack' ),
+					esc_attr( edd_get_label_plural( true ) )
 				);
 				?>
 				</label>

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -175,7 +175,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			// sanitize category.
 			$instance['category'] = $new_instance['category'] ? strip_tags( $new_instance['category'] ) : 'edd-all-categories';

--- a/widgets/edd-widget-most-recent.php
+++ b/widgets/edd-widget-most-recent.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'EDD_Most_Recent' ) ) {
 			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
 			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-			// contruct widget.
+			// construct widget.
 			parent::__construct( false, __( 'EDD Most Recent', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD most recent %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
 		}
 

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			return $instance;
 		}

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
 
 			return $instance;
 		}
@@ -180,7 +180,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
+		public function __construct() {
 			parent::__construct( false, sprintf( __( 'EDD Random %s', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A random EDD %s.', 'edd-widgets-pack' ), edd_get_label_singular( true ) ) ) );
 		}
 
@@ -37,7 +37,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
 			// get the title and apply filters.
 			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
@@ -134,7 +134,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -160,7 +160,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
 			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -40,7 +40,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		function widget( $args, $instance ) {
 
 			// get the title and apply filters.
-			$title = apply_filters( 'widget_title', $instanc['title'] ? $instance['title'] : '' );
+			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
 			// get show price boolean.
 			$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 					// get the post thumbnail.
-					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+					if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 						$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
 						$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 				// start the list output.
 				$out .= "<ul class=\"widget-random-download\">\n";
 
-				// set the link .
+				// set the link structure.
 				$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
 				// filter the thumbnail size.

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -160,27 +160,27 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @since    1.0
 		 */
 		public function form( $instance ) {
-			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
 			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
 			?>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -123,7 +123,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 
 			}
 
-			// set the widgets containers.
+			// set the widget's containers.
 			echo $args['before_widget'] . $out . $args['after_widget'];
 
 		}
@@ -141,12 +141,10 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize show price.
-			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
-			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
-			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
@@ -162,7 +160,6 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-
 		function form( $instance ) {
 			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -167,19 +167,19 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -148,7 +148,6 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			return $instance;
 		}
@@ -181,7 +180,7 @@ if ( ! class_exists( 'EDD_Random_Download' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-random-download.php
+++ b/widgets/edd-widget-random-download.php
@@ -1,219 +1,209 @@
 <?php
-/** 
+/**
  * EDD Random Download Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Random Download Widget Class
  *
  * A random EDD download.
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 if ( ! class_exists( 'EDD_Random_Download' ) ) {
-    class EDD_Random_Download extends WP_Widget {
+	class EDD_Random_Download extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			parent::__construct( false, sprintf( __( 'EDD Random %s', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A random EDD %s.', 'edd-widgets-pack' ), edd_get_label_singular( true ) ) ) );
+		}
 
-        function __construct()
-        {
-            parent::__construct( false, sprintf( __( 'EDD Random %s', 'edd-widgets-pack' ), edd_get_label_singular() ), array( 'description' => sprintf( __( 'A random EDD %s.', 'edd-widgets-pack' ), edd_get_label_singular( true ) ) ) );
-        }
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
+			// get the title and apply filters.
+			$title = apply_filters( 'widget_title', $instanc['title'] ? $instance['title'] : '' );
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+			// get show price boolean.
+			$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;
 
-        function widget( $args, $instance )
-        {
+			// get the thumbnail boolean.
+			$thumbnail = isset( $instance['thumbnail'] ) && 1 === $instance['thumbnail'] ? 1 : 0;
 
-             // get the title and apply filters
-             $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
-             
-             // get show price boolean
-             $show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
+			// set the thumbnail size.
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-             // get the thumbnail boolean
-             $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
+			// start collecting the output.
+			$out = '';
 
-             // set the thumbnail size
-             $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
-             
-             // start collecting the output
-             $out = "";
+			// check if there is a title.
+			if ( $title ) {
+				// add the title to the ouput.
+				$out .= $args['before_title'] . $title . $args['after_title'];
+			}
 
-             // check if there is a title
-             if ( $title ) {
-                 // add the title to the ouput
-                 $out .= $args['before_title'] . $title . $args['after_title'];
-             }
+			// set the params.
+			$params = array(
+				'post_type'      => 'download',
+				'posts_per_page' =>  1,
+				'post_status'    => 'publish',
+				'orderby'        => 'rand',
+			);
 
-             // set the params
-             $params = array( 
-                 'post_type'      => 'download', 
-                 'posts_per_page' =>  1, 
-                 'post_status'    => 'publish', 
-                 'orderby'        => 'rand', 
-             );
+			// get the random download.
+			$random_download = get_posts( $params );
 
-             // get the random download
-             $random_download = get_posts( $params );
+			// check download.
+			if ( is_null( $random_download ) || empty( $random_download ) ) {
+			// return if there is no download.
+				return;
 
-             // check download
-             if ( is_null( $random_download ) || empty( $random_download ) ) {
-                 // return if there is no download
-                 return;
+			} else {
+				// start the list output.
+				$out .= "<ul class=\"widget-random-download\">\n";
 
-             } else {
-                 // start the list output
-                 $out .= "<ul class=\"widget-random-download\">\n";
-               
-                 // set the link structure
-                 $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
-               
-                 // filter the thumbnail size
-                 $thumbnail_size = apply_filters( 'edd_widgets_random_download_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
-               
-                 // loop trough the random download
-                 foreach ( $random_download as $download ) {
-                     // get the title 
-                     $title = apply_filters( 'the_title', $download->post_title, $download->ID );
-					 $title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
-               
-                    // get the post thumbnail
-                     if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                         $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                        $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                        $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                     } else {
-                         $out .= "<li>\n";
-                     }
-               
-                     // append the download's title
-                     $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
-                     
-                     // get the price
-                     if ( $show_price === 1 ) {
-                         if ( edd_has_variable_prices( $download->ID ) ) {
-                             $price = edd_price_range( $download->ID );
-                         } else {
-                             $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                         }
-                         $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price ); 
-                     }
-                     
-                     // finish this element
-                     $out .= "</li>\n";
-                 }
-               
-                 // finish the list
-                 $out .= "</ul>\n";
-               
-             }
+				// set the link .
+				$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-             // set the widget's containers
-             echo $args['before_widget'] . $out . $args['after_widget'];
+				// filter the thumbnail size.
+				$thumbnail_size = apply_filters( 'edd_widgets_random_download_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-         }
+				// loop through the random download.
+				foreach ( $random_download as $download ) {
+					// get the title.
+					$title = apply_filters( 'the_title', $download->post_title, $download->ID );
+					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
+					// get the post thumbnail.
+					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+						$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
+						$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+					} else {
+						$out .= "<li>\n";
+					}
 
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
+					// append the downloads title.
+					$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
+					// get the price.
+					if ( 1 === $show_price ) {
+						if ( edd_has_variable_prices( $download->ID ) ) {
+							$price = edd_price_range( $download->ID );
+						} else {
+							$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+						}
+						$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+					}
 
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
+					// finish this element.
+					$out .= "</li>\n";
+				}
 
-            // sanitize show price
-            $instance['show_price'] = strip_tags( $new_instance['show_price'] );
-            $instance['show_price'] = $instance['show_price'] === '1' ? 1 : 0;
-            
-            // sanitize thumbnail
-            $instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
-            $instance['thumbnail'] = $instance['thumbnail'] === '1' ? 1 : 0;
+				// finish the list.
+				$out .= "</ul>\n";
 
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+			}
 
-            return $instance;
-        }
+			// set the widgets containers.
+			echo $args['before_widget'] . $out . $args['after_widget'];
+
+		}
+
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
+
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
+
+			// sanitize show price.
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
+			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+
+			// sanitize thumbnail.
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
+			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+
+			// sanitize thumbnail size.
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+
+			return $instance;
+		}
 
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
+		function form( $instance ) {
+			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-            <?php
-        }
-        
-    }
+			?>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				</p>
+			<?php
+		}
+
+	}
 }
 
 
 /**
  * Register Random Download Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 
 if ( ! function_exists( 'edd_widgets_pack_register_random_download_widget' ) ) {
-    function edd_widgets_pack_register_random_download_widget() {
-        register_widget( 'EDD_Random_Download' );
-    }
+	function edd_widgets_pack_register_random_download_widget() {
+		register_widget( 'EDD_Random_Download' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_random_download_widget', 10 );

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -231,7 +231,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -271,10 +271,10 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
 					<?php
-					sprintf(
+					printf(
 						/* translators: the plural post type label */
-						__( 'Number of %s to show:', 'edd-widgets-pack' ),
-						edd_get_label_plural( true )
+						esc_html__( 'Number of %s to show:', 'edd-widgets-pack' ),
+						esc_attr( edd_get_label_plural( true ) )
 					);
 					?>
 					</label>
@@ -289,7 +289,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ! empty( $instance['limit'] ) ? (int) $new_instance['limit'] : 4;
+			$instance['limit'] = isset( $instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
+			$instance['limit'] = ! empty( $instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -1,14 +1,13 @@
 <?php
-/** 
+/**
  * EDD Related Downloads Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
-
+ */
 
 /**
  * EDD Related Downloads Widget Class
@@ -18,298 +17,294 @@
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
-    class EDD_Related_Downloads extends WP_Widget {
+	class EDD_Related_Downloads extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
-
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
-            
-            parent::__construct( false, sprintf( __( 'EDD Related %s', 'edd-widgets-pack' ), edd_get_label_plural() ), array( 'description' => sprintf( __( 'A list of EDD related %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			// hook updates.
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
+			parent::__construct( false, sprintf( __( 'EDD Related %s', 'edd-widgets-pack' ), edd_get_label_plural() ), array( 'description' => sprintf( __( 'A list of EDD related %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
+			global $post;
 
-        function widget( $args, $instance )
-        {
-            global $post;
-            
-            if ( ! is_singular( 'download' ) )
-            return;
+			if ( ! is_singular( 'download' ) ) {
+				return;
+			}
 
-            // get the title and apply filters
-            $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+			// get the title and apply filters.
+			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-            // set the limit 
-            $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
+			// set the limit.
+			$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-            // get show price boolean
-            $show_price = isset( $instance['show_price'] ) && $instance['show_price'] === 1 ? 1 : 0;
+			// get show price boolean.
+			$show_price = isset( $instance['show_price'] ) && 1 === $instance['show_price'] ? 1 : 0;
 
-            // get the thumbnail boolean
-            $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] === 1 ? 1 : 0;
+			// get the thumbnail boolean.
+			$thumbnail = isset( $instance['thumbnail'] ) && 1 === $instance['thumbnail'] ? 1 : 0;
 
-            // set the thumbnail size
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
+			// set the thumbnail size.
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-            // start collecting the output
-            $out = "";
+			// start collecting the output.
+			$out = '';
 
-            // check if there is a title
-            if ( $title ) {
-                // add the title to the ouput
-                $out .= $args['before_title'] . $title . $args['after_title'];
-            }
+			// check if there is a title.
+			if ( $title ) {
+				// add the title to the ouput.
+				$out .= $args['before_title'] . $title . $args['after_title'];
+			}
 
-            // verify there is a post
-            if ( ! isset( $post->post_type ) || $post->post_type != 'download' )
-            return;
+			// verify there is a post.
+			if ( ! isset( $post->post_type ) || 'download' !== $post->post_type ) {
+				return;
+			}
 
-            // initialize array
-            $related_downloads = array();
+			// initialize array.
+			$related_downloads = array();
 
-            // get the post taxonomies
-            $taxonomies = get_object_taxonomies( $post, 'objects' );
+			// get the post taxonomies.
+			$taxonomies = get_object_taxonomies( $post, 'objects' );
 
-            // verify there is a taxonomy
-            if ( empty( $taxonomies ) )
-            return;
+			// verify there is a taxonomy.
+			if ( empty( $taxonomies ) ) {
+				return;
+			}
 
-            // loop and get terms
-            $terms_in = array();
-            $i = 0;
-            foreach ( $taxonomies as $taxonomy ) {
-                $terms = get_the_terms( $post->ID, $taxonomy->name );
-                $terms_in[$i]['tax'] = $taxonomy->name;
-                if ( ! empty( $terms ) ) 
-                foreach ( $terms as $term ) {
-                    $terms_in[$i]['terms'][] = $term->term_id;
-                }
-                $i++;
-            }
+			// loop and get terms.
+			$terms_in = array();
+			$i        = 0;
+			foreach ( $taxonomies as $taxonomy ) {
+				$terms                 = get_the_terms( $post->ID, $taxonomy->name );
+				$terms_in[ $i ]['tax'] = $taxonomy->name;
+				if ( ! empty( $terms ) ) {
+					foreach ( $terms as $term ) {
+						$terms_in[ $i ]['terms'][] = $term->term_id;
+					}
+					$i++;
+				}
+			}
 
-            $post_id = $post->ID;
-            $post_type = $post->post_type;
-            $c = 0;
-            // loop and get related posts
-            while ( count( $related_downloads ) < $limit && isset( $terms_in[$c] ) ) {
+			$post_id   = $post->ID;
+			$post_type = $post->post_type;
+			$c         = 0;
+			// loop and get related posts.
+			$product_number = count( $related_downloads );
+			while ( $product_number < $limit && isset( $terms_in[ $c ] ) ) {
+				// check for tax and terms.
+				if ( ! isset( $terms_in[ $c ]['tax'] ) || ! isset( $terms_in[ $c ]['terms'] ) ) {
+					++$c;
+					continue;
+				}
 
-                // check for tax and terms
-                if ( ! isset( $terms_in[$c]['tax'] ) || ! isset( $terms_in[$c]['terms'] ) ) {
-                    $c = $c + 1;
-                    continue;
-                }
+				// loop with a max of 4 posts per query.
+				foreach ( $terms_in[ $c ]['terms'] as $key => $value ) {
+					$params = array(
+						'tax_query' => array(
+							array(
+								'taxonomy' => $terms_in[ $c ]['tax'],
+								'field'    => 'id',
+								'terms'    => $value,
+							),
+						),
+						'post_type'           => $post_type,
+						'post__not_in'        => array( $post_id ),
+						'numberposts'         => $limit,
+						'ignore_sticky_posts' => 1,
+						'post_status'         => 'publish',
+						'orderby'             => 'rand',
+					);
 
-                // loop with a max of 4 posts per query
-                foreach ( $terms_in[$c]['terms'] as $key => $value ) {
-                    $params = array( 
-                        'tax_query' => array( 
-                            array( 
-                                'taxonomy' => $terms_in[$c]['tax'], 
-                                'field' => 'id', 
-                                'terms' => $value
-                             )
-                        ), 
-                        'post_type' => $post_type, 
-                        'post__not_in' => array( $post_id ), 
-                        'numberposts' => $limit, 
-                        'ignore_sticky_posts' => 1, 
-                        'post_status' => 'publish', 
-                        'orderby' => 'rand', 
-                    );
+					$related = get_posts( $params );
 
-                    $related = get_posts( $params );
+					if ( ! empty( $related ) ) {
+						foreach ( $related as $related_download ) {
+							if ( count( $related_downloads ) === $limit ) {
+								break;
+							}
+							$related_downloads[ $related_download->ID ] = $related_download;
+						}
+					}
+				}
 
-                    if ( ! empty( $related ) ) {
-                        foreach ( $related as $related_download ) {
-                            if ( count( $related_downloads ) == $limit )  break;
-                            $related_downloads[$related_download->ID] = $related_download;
-                        }
-                    }
-                }
+				++$c;
 
-                $c = $c + 1;
+				// limit to 5 loops.
+				if ( $c > 5 ) {
+					break;
+				}
+			}
 
-                // limit to 5 loops
-                if ( $c > 5 ) break;
-            }
+			// return empty if there are no related downloads.
+			if ( empty( $related_downloads ) ) {
+				return;
+			}
 
-            // return empty if there are no related downloads
-            if ( empty( $related_downloads ) )
-            return;
+			// get the post type.
+			$post_type_obj = get_post_type_object( $post_type );
 
-            // get the post type
-            $post_type_obj = get_post_type_object( $post_type );
+			// start the list output.
+			$out .= "<ul class=\"widget-related-entries\">\n";
 
-            // start the list output
-            $out .= "<ul class=\"widget-related-entries\">\n";
+			// set the link structure.
+			$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-            // set the link structure
-            $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
+			// filter the thumbnail size.
+			$thumbnail_size = apply_filters( 'edd_widgets_related_downloads_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-            // filter the thumbnail size
-            $thumbnail_size = apply_filters( 'edd_widgets_related_downloads_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
+			// loop trough all downloads.
+			foreach ( $related_downloads as $download ) {
+				// get the title.
+				$title      = apply_filters( 'the_title', $download->post_title, $download->ID );
+				$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-            // loop trough all downloads
-            foreach ( $related_downloads as $download ) {
-                // get the title 
-                $title = apply_filters( 'the_title', $download->post_title, $download->ID );
-                $title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
+				// get the post thumbnail.
+				if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+					$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+					$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
+					$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+				} else {
+					$out .= "<li>\n";
+				}
 
-                // get the post thumbnail
-                if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                    $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                    $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                    $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                } else {
-                    $out .= "<li>\n";
-                }
+				// append the download's title.
+				$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-                // append the download's title
-                $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
+				// get the price.
+				if ( 1 === $show_price ) {
+					if ( edd_has_variable_prices( $download->ID ) ) {
+						$price = edd_price_range( $download->ID );
+					} else {
+						$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+					}
+					$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+				}
 
-                // get the price
-                if ( $show_price === 1 ) {
-                    if ( edd_has_variable_prices( $download->ID ) ) {
-                        $price = edd_price_range( $download->ID );
-                    } else {
-                        $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                    }
-                    $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
-                }
-                
-                // finish this element
-                $out .= "</li>\n";
-            }
-            // finish the list
-            $out .= "</ul>\n";
+				// finish this element.
+				$out .= "</li>\n";
+			}
+			// finish the list.
+			$out .= "</ul>\n";
 
-            echo $args['before_widget'] . $out . $args['after_widget'];
-        }
-
-
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
-
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
-
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
-
-            // sanitize limit
-            $instance['limit'] = strip_tags( $new_instance['limit'] );
-            $instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
-            
-            // sanitize show price
-            $instance['show_price'] = strip_tags( $new_instance['show_price'] );
-            $instance['show_price'] = $instance['show_price'] === '1' ? 1 : 0;
-            
-            // sanitize thumbnail
-            $instance['thumbnail'] = strip_tags( $new_instance['thumbnail'] );
-            $instance['thumbnail'] = $instance['thumbnail'] === '1' ? 1 : 0;
-
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
-
-            // delete cache
-            $this->delete_cache();
-
-            return $instance;
-        }
+			echo $args['before_widget'] . $out . $args['after_widget'];
+		}
 
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */    
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-        function delete_cache()
-        {
-            delete_transient( 'edd_widgets_related_downloads' );
-        }
+			// sanitize title.
+			$instance['title'] = strip_tags( $new_instance['title'] );
+
+			// sanitize limit.
+			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
+
+			// sanitize show price.
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
+			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+
+			// sanitize thumbnail.
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
+			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+
+			// sanitize thumbnail size.
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+
+			// delete cache.
+			$this->delete_cache();
+
+			return $instance;
+		}
 
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function delete_cache() {
+			delete_transient( 'edd_widgets_related_downloads' );
+		}
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-            <?php
-        }
-        
-    }
+			?>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				</p>
+			<?php
+		}
+
+	}
 }
 
 
 /**
  * Register Related Downloads Widget
- *  
+ *
  * @access   private
  * @return   void
  * @since    1.0
-*/
-
+ */
 if ( ! function_exists( 'edd_widgets_pack_register_related_downloads_widget' ) ) {
-    function edd_widgets_pack_register_related_downloads_widget() {
-        register_widget( 'EDD_Related_Downloads' );
-    }
+	function edd_widgets_pack_register_related_downloads_widget() {
+		register_widget( 'EDD_Related_Downloads' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_related_downloads_widget', 10 );

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -265,7 +265,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
@@ -273,7 +273,8 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 					<?php
 					sprintf(
 						/* translators: the plural post type label */
-						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+						__( 'Number of %s to show:', 'edd-widgets-pack' ),
+						edd_get_label_plural( true )
 					);
 					?>
 					</label>
@@ -281,14 +282,14 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -290,7 +290,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -231,7 +231,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
 
 			// delete cache.
 			$this->delete_cache();
@@ -278,7 +278,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 					);
 					?>
 					</label>
-					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -108,10 +108,11 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$post_type = $post->post_type;
 			$c         = 0;
 			// loop and get related posts.
-			while ( count( $related_downloads ) < $limit && isset( $terms_in[ $c ] ) ) {
+			$related_count = count( $related_downloads );
+			while ( isset( $terms_in[ $c ] ) && $related_count < $limit ) {
 				// check for tax and terms.
 				if ( ! isset( $terms_in[ $c ]['tax'] ) || ! isset( $terms_in[ $c ]['terms'] ) ) {
-					++$c;
+					$c++;
 					continue;
 				}
 
@@ -137,7 +138,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 
 					if ( ! empty( $related ) ) {
 						foreach ( $related as $related_download ) {
-							if ( count( $related_downloads ) === $limit ) {
+							if ( $related_count === $limit ) {
 								break;
 							}
 							$related_downloads[ $related_download->ID ] = $related_download;

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
+		public function __construct() {
 			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
@@ -43,7 +43,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 			global $post;
 
 			if ( ! is_singular( 'download' ) ) {
@@ -214,7 +214,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
 			// sanitize title.
@@ -247,7 +247,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function delete_cache() {
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_related_downloads' );
 		}
 
@@ -257,7 +257,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
 			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -222,7 +222,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = isset( $instance['limit'] ) ? (int) $new_instance['limit'] : 4;
+			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 				// get the post thumbnail.
-				if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+				if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 					$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 					$out           .= "<li class=\"widget-download-with-thumbnail\">\n";
 					$out           .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -222,7 +222,6 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 
 			// sanitize limit.
 			$instance['limit'] = strip_tags( $new_instance['limit'] );
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
@@ -232,7 +231,6 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// delete cache.
 			$this->delete_cache();
@@ -271,7 +269,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
@@ -283,7 +281,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -108,8 +108,7 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$post_type = $post->post_type;
 			$c         = 0;
 			// loop and get related posts.
-			$product_number = count( $related_downloads );
-			while ( $product_number < $limit && isset( $terms_in[ $c ] ) ) {
+			while ( count( $related_downloads ) < $limit && isset( $terms_in[ $c ] ) ) {
 				// check for tax and terms.
 				if ( ! isset( $terms_in[ $c ]['tax'] ) || ! isset( $terms_in[ $c ]['terms'] ) ) {
 					++$c;
@@ -226,12 +225,10 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize show price.
-			$instance['show_price'] = ! empty( $new_instance['show_price'] ) ? strip_tags( $new_instance['show_price'] ) : '';
-			$instance['show_price'] = '1' === $instance['show_price'] ? 1 : 0;
+			$instance['show_price'] = ! empty( $new_instance['show_price'] ) && '1' === $new_instance['show_price'] ? 1 : 0;
 
 			// sanitize thumbnail.
-			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) ? strip_tags( $new_instance['thumbnail'] ) : '';
-			$instance['thumbnail'] = '1' === $instance['thumbnail'] ? 1 : 0;
+			$instance['thumbnail'] = ! empty( $new_instance['thumbnail'] ) && '1' === $new_instance['thumbnail'] ? 1 : 0;
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );

--- a/widgets/edd-widget-related-downloads.php
+++ b/widgets/edd-widget-related-downloads.php
@@ -264,24 +264,31 @@ if ( ! class_exists( 'EDD_Related_Downloads' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
+					<?php
+					sprintf(
+						/* translators: the plural post type label */
+						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					);
+					?>
+					</label>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label> 
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
+					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label> 
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
-					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label> 
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -227,10 +227,10 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
 					<?php
-					sprintf(
+					printf(
 						/* translators: the plural post type label */
-						__( 'Number of %s to show:', 'edd-widgets-pack' ),
-						edd_get_label_plural( true )
+						esc_html__( 'Number of %s to show:', 'edd-widgets-pack' ),
+						esc_attr( edd_get_label_plural( true ) )
 					);
 					?>
 					</label>
@@ -244,10 +244,10 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 					<input id="<?php echo esc_attr( $this->get_field_id( 'exclude_free' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'exclude_free' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_free' ) ); ?>">
 					<?php
-					sprintf(
+					printf(
 						/* translators: the plural post type label */
-						__( 'Exclude free %s?', 'edd-widgets-pack' ),
-						strtolower( edd_get_label_plural() )
+						esc_html__( 'Exclude free %s?', 'edd-widgets-pack' ),
+						esc_attr( strtolower( edd_get_label_plural() ) )
 					);
 					?>
 					</label>
@@ -257,7 +257,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ! empty( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
+			$instance['limit'] = isset( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -185,7 +185,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 			$instance['thumbnail'] = isset( $new_instance['thumbnail'] ) ? (bool) $new_instance['thumbnail'] : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
+			$instance['thumbnail_size'] = ! empty( $new_instance['thumbnail_size'] ) ? absint( $new_instance['thumbnail_size'] ) : 80;
 
 			// delete cache.
 			$this->delete_cache();

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -7,7 +7,7 @@
  * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
-*/
+ */
 
 /**
  * EDD Top Sellers Widget Class
@@ -174,7 +174,6 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 
 			// sanitize limit.
 			$instance['limit'] = strip_tags( $new_instance['limit'] );
-			$instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;
@@ -187,7 +186,6 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 
 			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
 			// delete cache.
 			$this->delete_cache();
@@ -228,7 +226,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
@@ -244,7 +242,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -212,37 +212,52 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 * @since    1.0
 		 */
 		public function form( $instance ) {
-			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-			$exclude_free = isset( $instance['exclude_free'] ) ? esc_attr( $instance['exclude_free'] ) : 0;
-			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$title          = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$limit          = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price     = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$exclude_free   = isset( $instance['exclude_free'] ) ? esc_attr( $instance['exclude_free'] ) : 0;
+			$thumbnail      = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
 			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
 
 			?>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-					<input type="number" min="-1" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>">
+					<?php
+					sprintf(
+						/* translators: the plural post type label */
+						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+					);
+					?>
+					</label>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'exclude_free' ); ?>" name="<?php echo $this->get_field_name( 'exclude_free' ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'exclude_free' ); ?>"><?php printf( __( 'Exclude free %s?', 'edd-widgets-pack' ), strtolower( edd_get_label_plural() ) ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'exclude_free' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'exclude_free' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_free' ) ); ?>">
+					<?php
+					sprintf(
+						/* translators: the plural post type label */
+						__( 'Exclude free %s?', 'edd-widgets-pack' ),
+						strtolower( edd_get_label_plural() )
+					);
+					?>
+					</label>
 				</p>
 				<p>
-					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-					<input type="number" min="0" class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -27,14 +27,14 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function __construct() {
-			// hook updates
+		public function __construct() {
+			// hook updates.
 			add_action( 'save_post', array( &$this, 'delete_cache' ) );
 			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
 			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
 			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-			// contruct widget
+			// contruct widget.
 			parent::__construct( false, __( 'EDD Top Sellers', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD top selling %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
 		}
 
@@ -45,33 +45,33 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function widget( $args, $instance ) {
+		public function widget( $args, $instance ) {
 
-			// get the title and apply filters
+			// get the title and apply filters.
 			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-			// set the limit
+			// set the limit.
 			$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-			// get show price boolean
+			// get show price boolean.
 			$show_price = isset( $instance['show_price'] ) && $instance['show_price'] == 1 ? 1 : 0;
 
-			// get the thumbnail boolean
+			// get the thumbnail boolean.
 			$thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] == 1 ? 1 : 0;
 
-			// set the thumbnail size
+			// set the thumbnail size.
 			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-			// start collecting the output
-			$out = "";
+			// start collecting the output.
+			$out = '';
 
-			// check if there is a title
+			// check if there is a title.
 			if ( $title ) {
-				// add the title to the ouput
+				// add the title to the ouput.
 				$out .= $args['before_title'] . $title . $args['after_title'];
 			}
 
-			// set the params
+			// set the params.
 			$params = array(
 				'post_type'      => 'download',
 				'posts_per_page' => absint( $limit ),
@@ -86,47 +86,47 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 						'order'   => 'DESC',
 					),
 				),
-				);
+			);
 
 			if ( $instance['exclude_free'] ) {
 				$params['meta_query'][] = array(
 					'key'     => 'edd_price',
 					'value'   => 0.00,
 					'type'    => 'numeric',
-					'compare' => '!='
+					'compare' => '!=',
 				);
 			}
 
-			// get top sellers
+			// get top sellers.
 			$top_sellers = get_posts( $params );
 
-			// check top sellers
+			// check top sellers.
 			if ( is_null( $top_sellers ) || empty( $top_sellers ) ) {
-				// return if there are no top sellers
+				// return if there are no top sellers.
 				return;
 
 			} else {
 
-				// start the list output
+				// start the list output.
 				$out .= "<ul class=\"widget-top-sellers\">\n";
 
-				// set the link structure
+				// set the link structure.
 				$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-				// filter the thumbnail size
+				// filter the thumbnail size.
 				$thumbnail_size = apply_filters( 'edd_widgets_top_sellers_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-				// loop trough all downloads
+				// loop trough all downloads.
 				foreach ( $top_sellers as $download ) {
 
 					setup_postdata( $download );
 
-					// get the title
-					$title = apply_filters( 'the_title', $download->post_title, $download->ID );
+					// get the title.
+					$title      = apply_filters( 'the_title', $download->post_title, $download->ID );
 					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-					// get the post thumbnail
-					if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+					// get the post thumbnail.
+					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
 						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 						$out .= "<li class=\"widget-download-with-thumbnail\">\n";
 						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
@@ -134,11 +134,11 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 						$out .= "<li>\n";
 					}
 
-					// append the download's title
+					// append the download's title.
 					$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-					// get the price
-					if ( $show_price === 1 ) {
+					// get the price.
+					if ( 1 === $show_price ) {
 						if ( edd_has_variable_prices( $download->ID ) ) {
 							$price = edd_price_range( $download->ID );
 						} else {
@@ -147,15 +147,15 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 						$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
 					}
 
-					// finish this element
+					// finish this element.
 					$out .= "</li>\n";
 				}
 				wp_reset_postdata();
-				// finish the list
+				// finish the list.
 				$out .= "</ul>\n";
 			}
 
-			// set the widget's containers
+			// set the widget's containers.
 			echo $args['before_widget'] . $out . $args['after_widget'];
 		}
 
@@ -166,30 +166,30 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 * @return   array
 		 * @since    1.0
 		 */
-		function update( $new_instance, $old_instance ) {
+		public function update( $new_instance, $old_instance ) {
 			$instance = $old_instance;
 
-			// sanitize title
+			// sanitize title.
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
-			// sanitize limit
+			// sanitize limit.
 			$instance['limit'] = strip_tags( $new_instance['limit'] );
 			$instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
 
-			// sanitize show price
+			// sanitize show price.
 			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;
 
-			// sanitize exclude free
+			// sanitize exclude free.
 			$instance['exclude_free'] = isset( $new_instance['exclude_free'] ) ? (bool) $new_instance['exclude_free'] : 0;
 
-			// sanitize thumbnail
+			// sanitize thumbnail.
 			$instance['thumbnail'] = isset( $new_instance['thumbnail'] ) ? (bool) $new_instance['thumbnail'] : 0;
 
-			// sanitize thumbnail size
+			// sanitize thumbnail size.
 			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
 			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
 
-			// delete cache
+			// delete cache.
 			$this->delete_cache();
 
 			return $instance;
@@ -201,9 +201,8 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 *
 		 * @return   void
 		 * @since    1.0
-		*/
-
-		function delete_cache() {
+		 */
+		public function delete_cache() {
 			delete_transient( 'edd_widgets_top_sellers' );
 		}
 
@@ -214,7 +213,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 		 * @return   void
 		 * @since    1.0
 		 */
-		function form( $instance ) {
+		public function form( $instance ) {
 			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
 			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
 			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -221,7 +221,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 
 			?>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_attr__( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title:', 'edd-widgets-pack' ); ?></label>
 					<input class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>" type="text" value="<?php echo esc_html( $title ); ?>"/>
 				</p>
 				<p>
@@ -229,7 +229,8 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 					<?php
 					sprintf(
 						/* translators: the plural post type label */
-						__( 'Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true )
+						__( 'Number of %s to show:', 'edd-widgets-pack' ),
+						edd_get_label_plural( true )
 					);
 					?>
 					</label>
@@ -237,7 +238,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_attr__( 'Display price?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>"><?php esc_html_e( 'Display price?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'exclude_free' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'exclude_free' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
@@ -253,10 +254,10 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_attr__( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail' ) ); ?>"><?php esc_html_e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
 				</p>
 				<p>
-					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_attr__( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php esc_html_e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
 					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
+			$instance['limit'] = ! empty( $new_instance['limit'] ) ? (int) $new_instance['limit'] : 4;
 
 			// sanitize show price.
 			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -126,7 +126,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
 					// get the post thumbnail.
-					if ( 1 === $thumbnail && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+					if ( 1 === $thumbnail && has_post_thumbnail( $download->ID ) ) {
 						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
 						$out .= "<li class=\"widget-download-with-thumbnail\">\n";
 						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 			$instance['title'] = strip_tags( $new_instance['title'] );
 
 			// sanitize limit.
-			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( (bool) preg_match( '/^\-?[0-9]+$/', $new_instance['limit'] ) );
 
 			// sanitize show price.
 			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;
@@ -185,7 +185,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 			$instance['thumbnail'] = isset( $new_instance['thumbnail'] ) ? (bool) $new_instance['thumbnail'] : 0;
 
 			// sanitize thumbnail size.
-			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( (bool) preg_match( '/^[0-9]+$/', $new_instance['thumbnail_size'] ) );
 
 			// delete cache.
 			$this->delete_cache();
@@ -234,7 +234,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 					);
 					?>
 					</label>
-					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" type="text" value="<?php echo esc_html( $limit ); ?>"/>
+					<input type="number" min="-1" class="small-text" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>" value="<?php echo esc_html( $limit ); ?>"/>
 				</p>
 				<p>
 					<input id="<?php echo esc_attr( $this->get_field_id( 'show_price' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'show_price' ) ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
@@ -258,7 +258,7 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
 				</p>
 				<p>
 					<label for="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>"><?php echo wp_kses( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', array( 'em' => array() ) ); ?></label>
-					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" type="text" value="<?php echo esc_html( $thumbnail_size ); ?>" />
+					<input type="number" min="0" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'thumbnail_size' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'thumbnail_size' ) ); ?>" value="<?php echo esc_html( $thumbnail_size ); ?>" />
 				</p>
 			<?php
 		}

--- a/widgets/edd-widget-top-sellers.php
+++ b/widgets/edd-widget-top-sellers.php
@@ -3,12 +3,11 @@
  * EDD Top Sellers Widget
  *
  * @package      EDD Widgets Pack
- * @author       Matt Varone <contact@mattvarone.com>
- * @copyright    Copyright (c) 2012, Matt Varone
+ * @author       Sandhills Development, LLC
+ * @copyright    Copyright (c) 2021, Sandhills Development, LLC
  * @license      http://opensource.org/licenses/gpl-2.0.php GNU Public License
  * @since        1.0
 */
-
 
 /**
  * EDD Top Sellers Widget Class
@@ -18,249 +17,240 @@
  * @access   private
  * @return   void
  * @since    1.0
-*/
+ */
 if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
-    class EDD_Top_Sellers extends WP_Widget {
+	class EDD_Top_Sellers extends WP_Widget {
 
-        /**
-         * Construct
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Construct
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function __construct() {
+			// hook updates
+			add_action( 'save_post', array( &$this, 'delete_cache' ) );
+			add_action( 'delete_post', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
+			add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
 
-        function __construct()
-        {
-            // hook updates
-            add_action( 'save_post', array( &$this, 'delete_cache' ) );
-            add_action( 'delete_post', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_start_of_week', array( &$this, 'delete_cache' ) );
-            add_action( 'update_option_gmt_offset', array( &$this, 'delete_cache' ) );
-
-            // contruct widget
-            parent::__construct( false, __( 'EDD Top Sellers', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD top selling %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
-        }
+			// contruct widget
+			parent::__construct( false, __( 'EDD Top Sellers', 'edd-widgets-pack' ), array( 'description' => sprintf( __( 'A list of EDD top selling %s.', 'edd-widgets-pack' ), edd_get_label_plural( true ) ) ) );
+		}
 
 
-        /**
-         * Widget
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Widget
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function widget( $args, $instance ) {
 
-        function widget( $args, $instance )
-        {
+			// get the title and apply filters
+			$title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
 
-            // get the title and apply filters
-            $title = apply_filters( 'widget_title', $instance['title'] ? $instance['title'] : '' );
+			// set the limit
+			$limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
 
-            // set the limit
-            $limit = isset( $instance['limit'] ) ? $instance['limit'] : 4;
+			// get show price boolean
+			$show_price = isset( $instance['show_price'] ) && $instance['show_price'] == 1 ? 1 : 0;
 
-            // get show price boolean
-            $show_price = isset( $instance['show_price'] ) && $instance['show_price'] == 1 ? 1 : 0;
+			// get the thumbnail boolean
+			$thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] == 1 ? 1 : 0;
 
-            // get the thumbnail boolean
-            $thumbnail = isset( $instance['thumbnail'] ) && $instance['thumbnail'] == 1 ? 1 : 0;
+			// set the thumbnail size
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
 
-            // set the thumbnail size
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? $instance['thumbnail_size'] : 80;
+			// start collecting the output
+			$out = "";
 
-            // start collecting the output
-            $out = "";
+			// check if there is a title
+			if ( $title ) {
+				// add the title to the ouput
+				$out .= $args['before_title'] . $title . $args['after_title'];
+			}
 
-            // check if there is a title
-            if ( $title ) {
-                // add the title to the ouput
-                $out .= $args['before_title'] . $title . $args['after_title'];
-            }
+			// set the params
+			$params = array(
+				'post_type'      => 'download',
+				'posts_per_page' => absint( $limit ),
+				'post_status'    => 'publish',
+				'orderby' => 'meta_value_num',
+				'meta_query'     => array(
+					'relation' => 'AND',
+					array(
+						'key'     => '_edd_download_sales',
+						'compare' => '>',
+						'value'   => 0,
+						'order'   => 'DESC',
+					),
+				),
+				);
 
-            // set the params
-            $params = array(
-                'post_type'      => 'download',
-                'posts_per_page' => absint( $limit ),
-                'post_status'    => 'publish',
-                'orderby' => 'meta_value_num',
-                'meta_query'     => array(
-                    'relation' => 'AND',
-                    array(
-                        'key'     => '_edd_download_sales',
-                        'compare' => '>',
-                        'value'   => 0,
-                        'order'   => 'DESC',
-                    ),
-                ),
-             );
+			if ( $instance['exclude_free'] ) {
+				$params['meta_query'][] = array(
+					'key'     => 'edd_price',
+					'value'   => 0.00,
+					'type'    => 'numeric',
+					'compare' => '!='
+				);
+			}
 
-            if ( $instance['exclude_free'] ) {
-                $params['meta_query'][] = array(
-                    'key'     => 'edd_price',
-                    'value'   => 0.00,
-                    'type'    => 'numeric',
-                    'compare' => '!='
-                );
-            }
+			// get top sellers
+			$top_sellers = get_posts( $params );
 
-            // get top sellers
-            $top_sellers = get_posts( $params );
+			// check top sellers
+			if ( is_null( $top_sellers ) || empty( $top_sellers ) ) {
+				// return if there are no top sellers
+				return;
 
-            // check top sellers
-            if ( is_null( $top_sellers ) || empty( $top_sellers ) ) {
-                // return if there are no top sellers
-                return;
+			} else {
 
-            } else {
+				// start the list output
+				$out .= "<ul class=\"widget-top-sellers\">\n";
 
-                // start the list output
-                $out .= "<ul class=\"widget-top-sellers\">\n";
+				// set the link structure
+				$link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
 
-                // set the link structure
-                $link = "<a href=\"%s\" title=\"%s\" class=\"%s\" rel=\"bookmark\">%s</a>\n";
+				// filter the thumbnail size
+				$thumbnail_size = apply_filters( 'edd_widgets_top_sellers_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
 
-                // filter the thumbnail size
-                $thumbnail_size = apply_filters( 'edd_widgets_top_sellers_thumbnail_size', array( $thumbnail_size, $thumbnail_size ) );
+				// loop trough all downloads
+				foreach ( $top_sellers as $download ) {
 
-                // loop trough all downloads
-                foreach ( $top_sellers as $download ) {
+					setup_postdata( $download );
 
-                    setup_postdata( $download );
-
-                    // get the title
-                    $title = apply_filters( 'the_title', $download->post_title, $download->ID );
+					// get the title
+					$title = apply_filters( 'the_title', $download->post_title, $download->ID );
 					$title_attr = apply_filters( 'the_title_attribute', $download->post_title, $download->ID );
 
-                    // get the post thumbnail
-                    if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
-                        $post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
-                        $out .= "<li class=\"widget-download-with-thumbnail\">\n";
-                        $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
-                    } else {
-                        $out .= "<li>\n";
-                    }
+					// get the post thumbnail
+					if ( $thumbnail === 1 && function_exists( 'has_post_thumbnail' ) && has_post_thumbnail( $download->ID ) ) {
+						$post_thumbnail = get_the_post_thumbnail( $download->ID, $thumbnail_size, array( 'title' => esc_attr( $title_attr ) ) ) . "\n";
+						$out .= "<li class=\"widget-download-with-thumbnail\">\n";
+						$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-thumb', $post_thumbnail );
+					} else {
+						$out .= "<li>\n";
+					}
 
-                    // append the download's title
-                    $out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
+					// append the download's title
+					$out .= sprintf( $link, get_permalink( $download->ID ), esc_attr( $title_attr ), 'widget-download-title', $title );
 
-                    // get the price
-                    if ( $show_price === 1 ) {
-                        if ( edd_has_variable_prices( $download->ID ) ) {
-                            $price = edd_price_range( $download->ID );
-                        } else {
-                            $price = edd_currency_filter( edd_get_download_price( $download->ID ) );
-                        }
-                        $out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
-                    }
+					// get the price
+					if ( $show_price === 1 ) {
+						if ( edd_has_variable_prices( $download->ID ) ) {
+							$price = edd_price_range( $download->ID );
+						} else {
+							$price = edd_currency_filter( edd_get_download_price( $download->ID ) );
+						}
+						$out .= sprintf( "<span class=\"widget-download-price\">%s</span>\n", $price );
+					}
 
-                    // finish this element
-                    $out .= "</li>\n";
-                }
-                wp_reset_postdata();
-                // finish the list
-                $out .= "</ul>\n";
-            }
+					// finish this element
+					$out .= "</li>\n";
+				}
+				wp_reset_postdata();
+				// finish the list
+				$out .= "</ul>\n";
+			}
 
-            // set the widget's containers
-            echo $args['before_widget'] . $out . $args['after_widget'];
-        }
-
-
-        /**
-         * Update
-         *
-         * @return   array
-         * @since    1.0
-        */
-
-        function update( $new_instance, $old_instance )
-        {
-            $instance = $old_instance;
-
-            // sanitize title
-            $instance['title'] = strip_tags( $new_instance['title'] );
-
-            // sanitize limit
-            $instance['limit'] = strip_tags( $new_instance['limit'] );
-            $instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
-
-            // sanitize show price
-            $instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;
-
-            // sanitize exclude free
-            $instance['exclude_free'] = isset( $new_instance['exclude_free'] ) ? (bool) $new_instance['exclude_free'] : 0;
-
-            // sanitize thumbnail
-            $instance['thumbnail'] = isset( $new_instance['thumbnail'] ) ? (bool) $new_instance['thumbnail'] : 0;
-
-            // sanitize thumbnail size
-            $instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
-            $instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
-
-            // delete cache
-            $this->delete_cache();
-
-            return $instance;
-        }
+			// set the widget's containers
+			echo $args['before_widget'] . $out . $args['after_widget'];
+		}
 
 
-        /**
-         * Delete Cache
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Update
+		 *
+		 * @return   array
+		 * @since    1.0
+		 */
+		function update( $new_instance, $old_instance ) {
+			$instance = $old_instance;
 
-        function delete_cache()
-        {
-            delete_transient( 'edd_widgets_top_sellers' );
-        }
+			// sanitize title
+			$instance['title'] = strip_tags( $new_instance['title'] );
+
+			// sanitize limit
+			$instance['limit'] = strip_tags( $new_instance['limit'] );
+			$instance['limit'] = ( ( bool ) preg_match( '/^\-?[0-9]+$/', $instance['limit'] ) ) && $instance['limit'] > -2 ? $instance['limit'] : 4;
+
+			// sanitize show price
+			$instance['show_price'] = isset( $new_instance['show_price'] ) ? (bool) $new_instance['show_price'] : 0;
+
+			// sanitize exclude free
+			$instance['exclude_free'] = isset( $new_instance['exclude_free'] ) ? (bool) $new_instance['exclude_free'] : 0;
+
+			// sanitize thumbnail
+			$instance['thumbnail'] = isset( $new_instance['thumbnail'] ) ? (bool) $new_instance['thumbnail'] : 0;
+
+			// sanitize thumbnail size
+			$instance['thumbnail_size'] = strip_tags( $new_instance['thumbnail_size'] );
+			$instance['thumbnail_size'] = ( ( bool ) preg_match( '/^[0-9]+$/', $instance['thumbnail_size'] ) ) ? $instance['thumbnail_size'] : 80;
+
+			// delete cache
+			$this->delete_cache();
+
+			return $instance;
+		}
 
 
-        /**
-         * Form
-         *
-         * @return   void
-         * @since    1.0
-        */
+		/**
+		 * Delete Cache
+		 *
+		 * @return   void
+		 * @since    1.0
+		*/
 
-        function form( $instance )
-        {
-            $title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
-            $limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
-            $show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
-            $exclude_free = isset( $instance['exclude_free'] ) ? esc_attr( $instance['exclude_free'] ) : 0;
-            $thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
-            $thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
+		function delete_cache() {
+			delete_transient( 'edd_widgets_top_sellers' );
+		}
 
-            ?>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
-                    <input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'exclude_free' ); ?>" name="<?php echo $this->get_field_name( 'exclude_free' ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'exclude_free' ); ?>"><?php printf( __( 'Exclude free %s?', 'edd-widgets-pack' ), strtolower( edd_get_label_plural() ) ); ?></label>
-                </p>
-                <p>
-                    <input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
-                </p>
-                <p>
-                    <label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
-                    <input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
-                </p>
-            <?php
-        }
 
-    }
+		/**
+		 * Form
+		 *
+		 * @return   void
+		 * @since    1.0
+		 */
+		function form( $instance ) {
+			$title = isset( $instance['title'] ) ? esc_attr( $instance['title'] ) : '';
+			$limit = isset( $instance['limit'] ) ? esc_attr( $instance['limit'] ) : 4;
+			$show_price = isset( $instance['show_price'] ) ? esc_attr( $instance['show_price'] ) : 0;
+			$exclude_free = isset( $instance['exclude_free'] ) ? esc_attr( $instance['exclude_free'] ) : 0;
+			$thumbnail = isset( $instance['thumbnail'] ) ? esc_attr( $instance['thumbnail'] ) : 0;
+			$thumbnail_size = isset( $instance['thumbnail_size'] ) ? esc_attr( $instance['thumbnail_size'] ) : 80;
+
+			?>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php _e( 'Title:', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo $title; ?>"/>
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'limit' ); ?>"><?php printf( __('Number of %s to show:', 'edd-widgets-pack' ), edd_get_label_plural( true ) ); ?></label>
+					<input class="small" size="3" id="<?php echo $this->get_field_id( 'limit' ); ?>" name="<?php echo $this->get_field_name( 'limit' ); ?>" type="text" value="<?php echo $limit; ?>"/>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'show_price' ); ?>" name="<?php echo $this->get_field_name( 'show_price' ); ?>" type="checkbox" value="1" <?php checked( '1', $show_price ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'show_price' ); ?>"><?php _e( 'Display price?', 'edd-widgets-pack' ); ?></label>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'exclude_free' ); ?>" name="<?php echo $this->get_field_name( 'exclude_free' ); ?>" type="checkbox" value="1" <?php checked( '1', $exclude_free ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'exclude_free' ); ?>"><?php printf( __( 'Exclude free %s?', 'edd-widgets-pack' ), strtolower( edd_get_label_plural() ) ); ?></label>
+				</p>
+				<p>
+					<input id="<?php echo $this->get_field_id( 'thumbnail' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail' ); ?>" type="checkbox" value="1" <?php checked( '1', $thumbnail ); ?>/>
+					<label for="<?php echo $this->get_field_id( 'thumbnail' ); ?>"><?php _e( 'Display thumbnails?', 'edd-widgets-pack' ); ?></label>
+				</p>
+				<p>
+					<label for="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>"><?php _e( 'Size of the thumbnails, e.g. <em>80</em> = 80x80px', 'edd-widgets-pack' ); ?></label>
+					<input class="widefat" id="<?php echo $this->get_field_id( 'thumbnail_size' ); ?>" name="<?php echo $this->get_field_name( 'thumbnail_size' ); ?>" type="text" value="<?php echo $thumbnail_size; ?>" />
+				</p>
+			<?php
+		}
+
+	}
 }
 
 
@@ -270,11 +260,10 @@ if ( ! class_exists( 'EDD_Top_Sellers' ) ) {
  * @access   private
  * @return   void
  * @since    1.0
-*/
-
+ */
 if ( ! function_exists( 'edd_widgets_pack_register_top_sellers_widget' ) ) {
-    function edd_widgets_pack_register_top_sellers_widget() {
-        register_widget( 'EDD_Top_Sellers' );
-    }
+	function edd_widgets_pack_register_top_sellers_widget() {
+		register_widget( 'EDD_Top_Sellers' );
+	}
 }
 add_action( 'widgets_init', 'edd_widgets_pack_register_top_sellers_widget', 10 );


### PR DESCRIPTION
Fixes #16 
- Adds check for undefined indexes in Archives, Featured Downloads, Most Commented, Most Recent, Random and Related Downloads widgets.  I check to see if the value is empty and use an empty string as the fallback.  It is then reassigned in the next line, so I figure the fallback value doesn't matter too much.
- Lots of little formatting things such as:
    - Spaces to tabs **(I highly suggest hiding whitespace changes when reviewing.)**
    - Fix inline control structures
    - Yoda conditionals
  
A few things that I did not touch:
- Many functions are missing doc blocks and / or parameter declaration
- I know there can't be too many comments in code, but this may be an exception. 
   For example, every type of widget has this:
     ```
     // check if there is a title.
			if ( $title ) {
				// add the title to the ouput.
				$out .= $args['before_title'] . $title . $args['after_title'];
			} 
	```		
